### PR TITLE
Move InMemoryStorage into separate file

### DIFF
--- a/devtools/db_import/db_import/in_memory_storage.py
+++ b/devtools/db_import/db_import/in_memory_storage.py
@@ -1,0 +1,59 @@
+## Copyright 2023 The OpenXLA Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+import io
+from typing import Dict, Iterable, Optional
+
+
+class Blob:
+  """This class mocks a Blob from the google-cloud-storage package.
+     So far it only supports reading files. The contents is provided as a string.
+  """
+
+  def __init__(self, name: str, bucket: "Bucket", contents: str):
+    self.name = name
+    self.bucket = bucket
+    self.contents = contents
+
+  def open(self):
+    return io.StringIO(self.contents)
+
+
+class Bucket:
+  """This class mocks a Bucket from the google-cloud-storage package.
+     Blobs can be registered with `register_blob` and will then appear as present in the bucket.
+  """
+
+  def __init__(self):
+    self.contents: dict[str, str] = {}
+
+  def blob(self, name: str) -> Blob:
+    return Blob(name, self, self.contents[name])
+
+  def register_blob(self, name: str, contents: str):
+    self.contents[name] = contents
+    return self.blob(name)
+
+  def list_blobs(self, prefix: Optional[str] = None) -> Iterable[Blob]:
+    for name, content in self.contents.items():
+      if prefix and not name.startswith(prefix):
+        continue
+      yield Blob(name, self, content)
+
+
+class Client:
+  """This class mocks a Client from the google-cloud-storage package.
+     Buckets can be registered with `register_bucket` and will then appear as available.
+  """
+
+  def __init__(self):
+    self._buckets: Dict[str, Bucket] = {}
+
+  def register_bucket(self, name: str) -> Bucket:
+    return self._buckets.setdefault(name, Bucket())
+
+  def get_bucket(self, name: str) -> Bucket:
+    return self._buckets[name]

--- a/devtools/db_import/db_import/in_memory_storage_test.py
+++ b/devtools/db_import/db_import/in_memory_storage_test.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python
+## Copyright 2023 The OpenXLA Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+import unittest
+
+import in_memory_storage
+import storage
+
+
+class TestInMemoryStorage(unittest.TestCase):
+
+  def test_read_file(self):
+    client = in_memory_storage.Client()
+    self.assertTrue(isinstance(client, storage.Client))
+
+    bucket_name = "bucket"
+    client.register_bucket(bucket_name)
+    bucket = client.get_bucket(bucket_name)
+    self.assertTrue(isinstance(bucket, storage.Bucket))
+
+    content = "blibablub"
+    filename = "filename.txt"
+    bucket.register_blob(filename, content)
+    blob = bucket.blob(filename)
+
+    self.assertTrue(isinstance(blob, storage.Blob))
+    with blob.open() as fd:
+      self.assertEqual(content, fd.read())
+
+  def test_list_blobs(self):
+    client = in_memory_storage.Client()
+
+    bucket_name = "bucket"
+    client.register_bucket(bucket_name)
+    bucket = client.get_bucket(bucket_name)
+
+    content = "blibablub"
+    filename1 = "filename1.txt"
+    filename2 = "filename2.txt"
+    bucket.register_blob(filename1, content)
+    bucket.register_blob(filename2, content)
+
+    self.assertEqual(set(blob.name for blob in bucket.list_blobs()),
+                     set([filename1, filename2]))
+
+
+if __name__ == "__main__":
+  unittest.main()

--- a/devtools/db_import/db_import/local_storage.py
+++ b/devtools/db_import/db_import/local_storage.py
@@ -11,6 +11,8 @@
 import os
 import pathlib
 
+from typing import Optional
+
 
 class Blob:
 
@@ -32,10 +34,12 @@ class Bucket:
     self.name: str = name
     self.path: pathlib.Path = directory / name
 
-  def list_blobs(self):
+  def list_blobs(self, prefix: Optional[str] = None):
     for root, dirs, files in os.walk(self.path):
       for file in files:
-        yield Blob(pathlib.Path(root) / file, self)
+        blob = Blob(pathlib.Path(root) / file, self)
+        if not prefix or blob.name.startswith(prefix):
+          yield blob
 
   def blob(self, filepath: str):
     full_path = self.path / filepath

--- a/devtools/db_import/db_import/rules_test.py
+++ b/devtools/db_import/db_import/rules_test.py
@@ -5,42 +5,13 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-import io
 import json
 import pathlib
 import tempfile
 import unittest
 
 from rules import apply_rule_to_file, BenchmarkRunAlreadyPresentError
-
-
-# This class mocks a Blob from the google-cloud-storage package.
-# So far it only supports reading files. The contents is provided as a string.
-class Blob:
-
-  def __init__(self, name: str, bucket, contents: str):
-    self.name = name
-    self.bucket = bucket
-    self.contents = contents
-
-  def open(self):
-    return io.StringIO(self.contents)
-
-
-# This class mocks a Bucket from the google-cloud-storage package.
-# Blobs can be registered with `registerBlob` and will then appear as present in the bucket.
-class Bucket:
-
-  def __init__(self):
-    self.contents: dict[str, str] = {}
-
-  def blob(self, name: str) -> Blob:
-    return Blob(name, self, self.contents[name])
-
-  def register_blob(self, name: str, contents: str):
-    self.contents[name] = contents
-    return self.blob(name)
-
+from in_memory_storage import Bucket
 
 EMPTY_CONFIG = {
     "bucket_name": "random_bucket_name",

--- a/devtools/db_import/db_import/storage.py
+++ b/devtools/db_import/db_import/storage.py
@@ -7,7 +7,7 @@
    Check out `local_storage` for an alternative implementation of these types.
 """
 
-from typing import Protocol, IO, Sequence, runtime_checkable
+from typing import Protocol, IO, Optional, Sequence, runtime_checkable
 
 
 @runtime_checkable
@@ -28,7 +28,7 @@ class Blob(Protocol):
 @runtime_checkable
 class Bucket(Protocol):
 
-  def list_blobs(self) -> Sequence[Blob]:
+  def list_blobs(self, prefix: Optional[str] = None) -> Sequence[Blob]:
     ...
 
   def blob(self, filepath: str) -> Blob:


### PR DESCRIPTION
The tests for the `rules` was using an in-memory implementation of the cloud storage client API. I'm moving this into a separate file to be able to use that from other tests as well.

The implementation is now also complete in the sense that it is implementing the previously established storage protocols.

It is also adding the `prefix` parameter to the list_blobs function in the protocol and in both implementations (`LocalStorage` and `InMemoryStorage`).