### PR TITLE
Add setup job to comparative benchmark workflow

### DIFF
--- a/.github/workflows/run_comparative_benchmark.yml
+++ b/.github/workflows/run_comparative_benchmark.yml
@@ -13,7 +13,6 @@ on:
     # Scheduled to run at 09:00 UTC and 21:00 UTC.
     - cron: '0 09,21 * * *'
   workflow_dispatch:
-  pull_request:
 
 concurrency:
   # A PR number if a pull request and otherwise the commit hash. This cancels

--- a/.github/workflows/run_comparative_benchmark.yml
+++ b/.github/workflows/run_comparative_benchmark.yml
@@ -32,6 +32,8 @@ jobs:
     outputs:
       runner-group: ${{ steps.configure.outputs.runner-group }}
     steps:
+      - name: "Checking out PR repository"
+        uses: actions/checkout@e2f20e631ae6d7dd3b768f56a5d2af784dd54791  # v2.5.0
       - name: "Configuring CI options"
         id: configure
         env:

--- a/.github/workflows/run_comparative_benchmark.yml
+++ b/.github/workflows/run_comparative_benchmark.yml
@@ -13,16 +13,37 @@ on:
     # Scheduled to run at 09:00 UTC and 21:00 UTC.
     - cron: '0 09,21 * * *'
   workflow_dispatch:
+  pull_request:
 
 env:
   # TODO(#20): Upload reuslts to "gs://comparative-benchmark-artifacts"
   GCS_DIR: gs://openxla-github-actions-${{ github.event_name == 'pull_request' && 'presubmit' || 'postsubmit' }}-artifacts/${{ github.run_id }}/${{ github.run_attempt }}
 
 jobs:
+  setup:
+    runs-on: ubuntu-22.04
+    outputs:
+      runner-group: ${{ steps.configure.outputs.runner-group }}
+    steps:
+      - name: "Configuring CI options"
+        id: configure
+        env:
+          RUNNER_GROUP: ${{ github.event_name == 'pull_request' && 'presubmit' || 'postsubmit' }}
+        run: |
+          # Just informative logging. There should only be two commits in the
+          # history here, but limiting the depth helps when copying from a local
+          # repo instead of using checkout, e.g. with
+          # https://github.com/nektos/act where there will be more.
+          git log --oneline --graph --max-count=3
+          # Workflow jobs can't access `env` in `runs-on`, so we need to make
+          # `runner-group` a job output variable.
+          echo "runner-group=${RUNNER_GROUP}" > "${GITHUB_OUTPUT}"
+
   benchmark_on_a2-highgpu-1g:
+    needs: setup
     runs-on:
       - self-hosted  # must come first
-      - runner-group=presubmit
+      - runner-group=${{ needs.setup.outputs.runner-group }}
       - environment=prod
       - machine-type=a2-highgpu-1g
     env:

--- a/.github/workflows/run_comparative_benchmark.yml
+++ b/.github/workflows/run_comparative_benchmark.yml
@@ -15,6 +15,13 @@ on:
   workflow_dispatch:
   pull_request:
 
+concurrency:
+  # A PR number if a pull request and otherwise the commit hash. This cancels
+  # queued and in-progress runs for the same PR (presubmit) or commit
+  # (postsubmit).
+  group: ${{ github.event.number || github.sha }}
+  cancel-in-progress: true
+
 env:
   # TODO(#20): Upload reuslts to "gs://comparative-benchmark-artifacts"
   GCS_DIR: gs://openxla-github-actions-${{ github.event_name == 'pull_request' && 'presubmit' || 'postsubmit' }}-artifacts/${{ github.run_id }}/${{ github.run_attempt }}


### PR DESCRIPTION
Add setup job to print informative git log and correctly decide runner group.