### PR TITLE
Use platform-specific JAX packages

### DIFF
--- a/common_benchmark_suite/openxla/benchmark/models/jax/t5_large/model.py
+++ b/common_benchmark_suite/openxla/benchmark/models/jax/t5_large/model.py
@@ -23,7 +23,8 @@ class T5Large(model_interfaces.InferenceModel):
     self.model = FlaxT5Model.from_pretrained("t5-large", return_dict=True)
 
   def generate_inputs(self) -> Tuple[Any, Any]:
-    tokenizer = AutoTokenizer.from_pretrained("t5-large")
+    tokenizer = AutoTokenizer.from_pretrained("t5-large",
+                                              model_max_length=self.seq_len)
     tokenization_kwargs = {
         "pad_to_multiple_of": self.seq_len,
         "padding": True,
@@ -49,7 +50,7 @@ class T5Large(model_interfaces.InferenceModel):
     return self.model(
         input_ids=encoder_input_ids,
         decoder_input_ids=decoder_input_ids,
-    )[0]
+    ).last_hidden_state
 
 
 def create_model(batch_size: int = 1,

--- a/comparative_benchmark/jax_xla/benchmark_all.sh
+++ b/comparative_benchmark/jax_xla/benchmark_all.sh
@@ -9,12 +9,18 @@
 set -xeuo pipefail
 
 VENV_DIR="${OOBI_VENV_DIR:-jax-benchmarks.venv}"
+PYTHON="${PYTHON:-/usr/bin/python3}"
 TARGET_DEVICE="${1:-${OOBI_TARGET_DEVICE}}"
 OUTPUT_PATH="${2:-${OOBI_OUTPUT}}"
 
 TD="$(cd $(dirname $0) && pwd)"
 
-VENV_DIR="${VENV_DIR}" source "${TD}/setup_venv.sh"
+if [ "${TARGET_DEVICE}" = "a2-highgpu-1g" ]; then
+  export WITH_CUDA=1
+fi
+
+VENV_DIR="${VENV_DIR}" PYTHON="${PYTHON}" source "${TD}/setup_venv.sh"
+unset WITH_CUDA
 
 declare -a GPU_BENCHMARK_NAMES=(
   "models/T5_LARGE_FP32_JAX_512XI32_BATCH1/inputs/.+/expected_outputs/.+/target_devices/a2-highgpu-1g"


### PR DESCRIPTION
Installs cpu-specific and cuda-specific JAX packages depending on which device is being benchmarked. Also some minor fixes to the JAX T5 implementation.