### PR TITLE
Fetch preprocessed inputs for benchmarking 

### DIFF
--- a/.github/workflows/run_comparative_benchmark.yml
+++ b/.github/workflows/run_comparative_benchmark.yml
@@ -13,7 +13,6 @@ on:
     # Scheduled to run at 09:00 UTC and 21:00 UTC.
     - cron: '0 09,21 * * *'
   workflow_dispatch:
-  pull_request:
 
 concurrency:
   # A PR number if a pull request and otherwise the commit hash. This cancels

--- a/.github/workflows/run_comparative_benchmark.yml
+++ b/.github/workflows/run_comparative_benchmark.yml
@@ -13,6 +13,7 @@ on:
     # Scheduled to run at 09:00 UTC and 21:00 UTC.
     - cron: '0 09,21 * * *'
   workflow_dispatch:
+  pull_request:
 
 concurrency:
   # A PR number if a pull request and otherwise the commit hash. This cancels

--- a/common_benchmark_suite/openxla/benchmark/comparative_suite/jax/model_definitions.py
+++ b/common_benchmark_suite/openxla/benchmark/comparative_suite/jax/model_definitions.py
@@ -37,14 +37,15 @@ T5_LARGE_FP32_JAX_512XI32_BATCH_TEMPLATE = utils.ModelTemplate(
                 artifact_type=def_types.ModelArtifactType.STABLEHLO,
                 source_url=string.Template(
                     PARENT_GCS_DIR +
-                    "/T5_LARGE/batch_${batch_size}/stablehlo.mlirbc"),
+                    "T5_LARGE_FP32_JAX_512XI32_BATCH${batch_size}/stablehlo.mlirbc"
+                ),
             ),
         def_types.ModelArtifactType.XLA_HLO_DUMP:
             utils.ModelArtifactTemplate(
                 artifact_type=def_types.ModelArtifactType.XLA_HLO_DUMP,
                 source_url=string.Template(
                     PARENT_GCS_DIR +
-                    "/T5_LARGE/batch_${batch_size}/hlo/jit_forward.before_optimizations.txt"
+                    "T5_LARGE_FP32_JAX_512XI32_BATCH${batch_size}/hlo/jit_forward.before_optimizations.txt"
                 ),
             ),
     },

--- a/common_benchmark_suite/openxla/benchmark/comparative_suite/jax/test_data_definitions.py
+++ b/common_benchmark_suite/openxla/benchmark/comparative_suite/jax/test_data_definitions.py
@@ -29,7 +29,7 @@ INPUT_DATA_T5_LARGE_JAX_SEQLEN512_I32_BATCH_TEMPLATE = utils.ModelTestDataTempla
                 },
                 verify_parameters={},
                 source_url=string.Template(
-                    "https://storage.googleapis.com/iree-model-artifacts/jax/jax_models_0.4.10_1684396752/T5_LARGE/batch_${batch_size}/input_npy.tgz"
+                    "https://storage.googleapis.com/iree-model-artifacts/jax/jax_models_0.4.10_1684396752/T5_LARGE_FP32_JAX_512XI32_BATCH${batch_size}/input_npy.tgz"
                 ))
     })
 INPUT_DATA_T5_LARGE_JAX_SEQLEN512_I32_BATCHES = utils.build_batch_model_test_data(
@@ -55,7 +55,7 @@ OUTPUT_DATA_T5_LARGE_FP32_JAX_512X1024XF32_BATCH_TEMPLATE = utils.ModelTestDataT
                 # TODO(#11): Add verification tolerance `0.5`.
                 verify_parameters={},
                 source_url=string.Template(
-                    "https://storage.googleapis.com/iree-model-artifacts/jax/jax_models_0.4.10_1684396752/T5_LARGE/batch_${batch_size}/output_npy.tgz"
+                    "https://storage.googleapis.com/iree-model-artifacts/jax/jax_models_0.4.10_1684396752/T5_LARGE_FP32_JAX_512XI32_BATCH${batch_size}/output_npy.tgz"
                 ))
     })
 OUTPUT_DATA_T5_LARGE_FP32_JAX_512X1024XF32_BATCHES = utils.build_batch_model_test_data(

--- a/comparative_benchmark/jax_xla/benchmark_all.sh
+++ b/comparative_benchmark/jax_xla/benchmark_all.sh
@@ -66,5 +66,6 @@ for benchmark_name in "${BENCHMARK_NAMES[@]}"; do
   "${TD}/run_benchmarks.py" \
     --benchmark_name="${benchmark_name}" \
     --output="${OUTPUT_PATH}" \
-    --iterations="${ITERATIONS}"
+    --iterations="${ITERATIONS}" \
+    --verbose
 done

--- a/comparative_benchmark/jax_xla/run_benchmarks.py
+++ b/comparative_benchmark/jax_xla/run_benchmarks.py
@@ -197,7 +197,8 @@ def _run(benchmark: def_types.BenchmarkCase, run_in_process: bool,
 
 
 def _download_artifacts(benchmarks: Sequence[def_types.BenchmarkCase],
-                        root_dir: pathlib.Path):
+                        root_dir: pathlib.Path,
+                        verbose: bool = False):
   """Download benchmark artifacts."""
 
   download_list = []
@@ -207,7 +208,7 @@ def _download_artifacts(benchmarks: Sequence[def_types.BenchmarkCase],
     input_path = root_dir / benchmark.model.name / "input_npy.tgz"
     download_list.append((artifact.source_url, input_path))
 
-  utils.download_files(download_list)
+  utils.download_files(download_list, verbose=verbose)
 
 
 def _parse_arguments() -> argparse.Namespace:
@@ -277,7 +278,9 @@ def main(
                      f' Available benchmarks:\n{all_benchmark_list}')
 
   if not no_download:
-    _download_artifacts(benchmarks=benchmarks, root_dir=root_dir)
+    _download_artifacts(benchmarks=benchmarks,
+                        root_dir=root_dir,
+                        verbose=verbose)
 
   benchmarks_to_inputs = {}
   for benchmark in benchmarks:

--- a/comparative_benchmark/utils.py
+++ b/comparative_benchmark/utils.py
@@ -6,9 +6,11 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+import concurrent.futures
 import pathlib
 import requests
 import tarfile
+from typing import List, Tuple
 
 
 def download_file(source_url: str,
@@ -38,3 +40,16 @@ def download_file(source_url: str,
     with tarfile.open(save_path) as tar_file:
       # If the tgz is at `x/y.tgz`, unpack at `x/y`.
       tar_file.extractall(save_path.with_suffix(""))
+
+
+def download_files(urls_to_paths: List[Tuple[str, pathlib.Path]]):
+  """Fetch a list of URLs in parallel."""
+
+  with concurrent.futures.ProcessPoolExecutor(8) as executor:
+    futures = []
+    for source_url, save_path in urls_to_paths:
+      futures.append(
+          executor.submit(download_file,
+                          source_url=source_url,
+                          save_path=save_path))
+    concurrent.futures.wait(futures)

--- a/comparative_benchmark/utils.py
+++ b/comparative_benchmark/utils.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+#
+# Copyright 2023 The OpenXLA Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+import pathlib
+import requests
+import tarfile
+
+
+def download_file(source_url: str,
+                  save_path: pathlib.Path,
+                  unpack: bool = True):
+  """Downloads `source_url` to `saved_path`.
+
+  NEVER use this function to download from untrusted sources, it doesn't unpack
+  the file safely.
+
+  Args:
+    source_url: URL to download.
+    save_path: Path to save the file.
+    unpack: Unarchive the .tgz if set. `x/y.tgz` will be unarchived to `x/y`.
+  """
+
+  save_path.parent.mkdir(parents=True, exist_ok=True)
+  with requests.get(source_url, stream=True) as response:
+    with save_path.open("wb") as f:
+      for chunk in response.iter_content(chunk_size=65536):
+        f.write(chunk)
+
+  if not unpack:
+    return
+
+  if save_path.suffix == ".tgz":
+    with tarfile.open(save_path) as tar_file:
+      # If the tgz is at `x/y.tgz`, unpack at `x/y`.
+      tar_file.extractall(save_path.with_suffix(""))

--- a/comparative_benchmark/utils.py
+++ b/comparative_benchmark/utils.py
@@ -15,7 +15,8 @@ from typing import List, Tuple
 
 def download_file(source_url: str,
                   save_path: pathlib.Path,
-                  unpack: bool = True):
+                  unpack: bool = True,
+                  verbose: bool = False):
   """Downloads `source_url` to `saved_path`.
 
   NEVER use this function to download from untrusted sources, it doesn't unpack
@@ -25,9 +26,14 @@ def download_file(source_url: str,
     source_url: URL to download.
     save_path: Path to save the file.
     unpack: Unarchive the .tgz if set. `x/y.tgz` will be unarchived to `x/y`.
+    verbose: Show downloading message.
   """
 
   save_path.parent.mkdir(parents=True, exist_ok=True)
+
+  if verbose:
+    print(f"Downloading '{source_url}' to '{save_path}'.")
+
   # requests doesn't clearly state its session is thread-safe. In order to
   # download in parallel, don't use session here.
   with requests.get(source_url, stream=True) as response:
@@ -45,7 +51,8 @@ def download_file(source_url: str,
 
 
 def download_files(urls_to_paths: List[Tuple[str, pathlib.Path]],
-                   max_workers: int = 8):
+                   max_workers: int = 8,
+                   verbose: bool = False):
   """Fetch a list of URLs in parallel."""
 
   with concurrent.futures.ThreadPoolExecutor(max_workers) as executor:
@@ -54,5 +61,6 @@ def download_files(urls_to_paths: List[Tuple[str, pathlib.Path]],
       futures.append(
           executor.submit(download_file,
                           source_url=source_url,
-                          save_path=save_path))
+                          save_path=save_path,
+                          verbose=verbose))
     concurrent.futures.wait(futures)

--- a/comparative_benchmark/utils.py
+++ b/comparative_benchmark/utils.py
@@ -34,7 +34,7 @@ def download_file(source_url: str,
   if verbose:
     print(f"Downloading '{source_url}' to '{save_path}'.")
 
-  # requests doesn't clearly state its session is thread-safe. In order to
+  # requests doesn't clearly state that its session is thread-safe. In order to
   # download in parallel, don't use session here.
   with requests.get(source_url, stream=True) as response:
     with save_path.open("wb") as f:

--- a/comparative_benchmark/utils.py
+++ b/comparative_benchmark/utils.py
@@ -28,6 +28,8 @@ def download_file(source_url: str,
   """
 
   save_path.parent.mkdir(parents=True, exist_ok=True)
+  # requests doesn't clearly state its session is thread-safe. In order to
+  # download in parallel, don't use session here.
   with requests.get(source_url, stream=True) as response:
     with save_path.open("wb") as f:
       for chunk in response.iter_content(chunk_size=65536):
@@ -42,10 +44,11 @@ def download_file(source_url: str,
       tar_file.extractall(save_path.with_suffix(""))
 
 
-def download_files(urls_to_paths: List[Tuple[str, pathlib.Path]]):
+def download_files(urls_to_paths: List[Tuple[str, pathlib.Path]],
+                   max_workers: int = 8):
   """Fetch a list of URLs in parallel."""
 
-  with concurrent.futures.ProcessPoolExecutor(8) as executor:
+  with concurrent.futures.ThreadPoolExecutor(max_workers) as executor:
     futures = []
     for source_url, save_path in urls_to_paths:
       futures.append(


### PR DESCRIPTION
Instead of generating input tensors from raw data every time, download the preprocessed input data from GCS.

This change also rearranges the GCS model artifact directory. Now it follows:

```
gs://.../${MODEL_NAME}_${BATCH_SIZE}/input_npy.tgz
gs://.../${MODEL_NAME}_${BATCH_SIZE}/output_npy.tgz
gs://.../${MODEL_NAME}_${BATCH_SIZE}/stablehlo.mlir
```

`input_npy.tgz` will pack multiple `.npy` if there are more than one input tensors.