### PR TITLE
Add batch import tool to DB import

### DIFF
--- a/devtools/db_import/cli.py
+++ b/devtools/db_import/cli.py
@@ -11,6 +11,7 @@ import yaml
 
 SCRIPT_DIR = pathlib.Path(__file__).resolve().parent
 
+from db_import.batch_import import configure_parser as configure_batch_import_parser
 from db_import.process import configure_parser as configure_process_parser
 
 parser = argparse.ArgumentParser(prog="cli",
@@ -24,6 +25,10 @@ parser.add_argument(
     default=SCRIPT_DIR / "config.yml",
 )
 subparsers = parser.add_subparsers(required=True)
+
+batch_import_parser = subparsers.add_parser(
+    "batch_import", help="Batch import an entire bucket")
+configure_batch_import_parser(batch_import_parser)
 
 process_parser = subparsers.add_parser(
     "process", help="Process a single file from a bucket")

--- a/devtools/db_import/db_import/batch_import.py
+++ b/devtools/db_import/db_import/batch_import.py
@@ -1,0 +1,97 @@
+## Copyright 2023 The OpenXLA Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+import argparse
+import sys
+
+from google.cloud import bigquery
+from google.cloud import storage
+from typing import Optional, Any, Dict
+
+from db_import.process import process_single_file
+from db_import.process import NoRuleAppliesError
+from db_import.rules import BenchmarkRunAlreadyPresentError
+from db_import import db
+
+
+def configure_parser(parser: argparse.ArgumentParser):
+  parser.set_defaults(command_handler=_batch_import)
+  parser.add_argument("config_name")
+  parser.add_argument(
+      "-s",
+      "--check",
+      help=
+      "Checks for each record if it already exists in the DB before importing (Warning: Slow!)",
+      action="store_true",
+  )
+
+
+def _batch_import(config_file, args: argparse.Namespace):
+  try:
+    config = config_file["cloud_functions"][args.config_name]
+  except KeyError:
+    sys.exit(f"No configuration with the name {args.config_name} found.")
+
+  db_client = bigquery.Client()
+  storage_client = storage.Client()
+
+  import_entire_bucket(
+      db_client,
+      storage_client,
+      config,
+      config_file.get("snippets", {}),
+      check_for_presence=args.check,
+  )
+
+
+# This function tries to import all files from a GCS bucket.
+# It lists all the files from the given bucket and behaves as
+# if each file was triggered seperately. The order is not enforced.
+def import_entire_bucket(
+    db_client: db.Client,
+    storage_client: storage.Client,
+    config: Dict[str, Any],
+    snippets: Dict[str, str],
+    check_for_presence: bool,
+    prefix_filter: Optional[str] = None,
+    dump_files_to: Optional[str] = None,
+):
+  bucket = storage_client.get_bucket(config["bucket_name"])
+  table = db_client.get_table(config["table_name"])
+
+  def presence_check(rule: Dict, parameters: Dict) -> bool:
+    return db.query_returns_non_empty_result(
+        db_client, rule["sql_condition"].format(table=table.table_id,
+                                                dataset=table.dataset_id),
+        parameters)
+
+  def process_single_file_with_status_output(file):
+    try:
+      print(f"Processing {file.name}... ", end="")
+
+      rows = process_single_file(
+          config["rules"],
+          file,
+          config,
+          snippets,
+          presence_check if check_for_presence else None,
+          dump_files_to,
+      )
+      if len(rows) > 0:
+        db_client.insert_rows(table, rows)
+      print("Done.")
+    except NoRuleAppliesError:
+      # This happens so often, that we don't wanna clutter the output, so
+      # we rather do a carriage return and re-use the same line.
+      print("No rule applies.\r" + " " * 250, end="\r")
+    except BenchmarkRunAlreadyPresentError:
+      print("Data already present.")
+    except Exception:
+      print("Failure.")
+
+  for file in bucket.list_blobs(
+      prefix=prefix_filter if prefix_filter else None):
+    process_single_file_with_status_output(file)

--- a/devtools/db_import/db_import/batch_import.py
+++ b/devtools/db_import/db_import/batch_import.py
@@ -11,9 +11,8 @@ from google.cloud import bigquery
 from google.cloud import storage
 from typing import Optional, Any, Dict
 
-from db_import.process import process_single_file
-from db_import.process import NoRuleAppliesError
-from db_import.rules import BenchmarkRunAlreadyPresentError
+from db_import import process
+from db_import import rules
 from db_import import db
 
 
@@ -72,7 +71,7 @@ def import_entire_bucket(
     try:
       print(f"Processing {file.name}... ", end="")
 
-      rows = process_single_file(
+      rows = process.process_single_file(
           config["rules"],
           file,
           config,
@@ -83,11 +82,11 @@ def import_entire_bucket(
       if len(rows) > 0:
         db_client.insert_rows(table, rows)
       print("Done.")
-    except NoRuleAppliesError:
+    except process.NoRuleAppliesError:
       # This happens so often, that we don't wanna clutter the output, so
       # we rather do a carriage return and re-use the same line.
       print("No rule applies.\r" + " " * 250, end="\r")
-    except BenchmarkRunAlreadyPresentError:
+    except process.BenchmarkRunAlreadyPresentError:
       print("Data already present.")
     except Exception as e:
       print("Failure:")

--- a/devtools/db_import/db_import/batch_import.py
+++ b/devtools/db_import/db_import/batch_import.py
@@ -89,8 +89,9 @@ def import_entire_bucket(
       print("No rule applies.\r" + " " * 250, end="\r")
     except BenchmarkRunAlreadyPresentError:
       print("Data already present.")
-    except Exception:
-      print("Failure.")
+    except Exception as e:
+      print("Failure:")
+      print(e)
 
   for file in bucket.list_blobs(
       prefix=prefix_filter if prefix_filter else None):

--- a/devtools/db_import/db_import/batch_import_test.py
+++ b/devtools/db_import/db_import/batch_import_test.py
@@ -8,7 +8,7 @@ import contextlib
 import io
 import unittest
 
-from db_import.batch_import import import_entire_bucket
+from db_import import batch_import
 from db_import import in_memory_storage
 from db_import import in_memory_database
 
@@ -30,11 +30,11 @@ class TestImportEntireBucket(unittest.TestCase):
     storage_client = in_memory_storage.Client()
     storage_client.register_bucket("random_bucket_name")
 
-    import_entire_bucket(db_client,
-                         storage_client,
-                         config,
-                         snippets={},
-                         check_for_presence=False)
+    batch_import.import_entire_bucket(db_client,
+                                      storage_client,
+                                      config,
+                                      snippets={},
+                                      check_for_presence=False)
     self.assertEqual(table.rows, [])
 
   def test_no_match(self):
@@ -53,11 +53,11 @@ class TestImportEntireBucket(unittest.TestCase):
     storage_client.register_bucket("random_bucket_name").register_blob(
         "hello.json", "")
 
-    import_entire_bucket(db_client,
-                         storage_client,
-                         config,
-                         snippets={},
-                         check_for_presence=False)
+    batch_import.import_entire_bucket(db_client,
+                                      storage_client,
+                                      config,
+                                      snippets={},
+                                      check_for_presence=False)
     self.assertEqual(table.rows, [])
 
   def test_single_file(self):
@@ -77,11 +77,11 @@ class TestImportEntireBucket(unittest.TestCase):
         "hello.json", "")
 
     with contextlib.redirect_stdout(io.StringIO()):
-      import_entire_bucket(db_client,
-                           storage_client,
-                           config,
-                           snippets={},
-                           check_for_presence=False)
+      batch_import.import_entire_bucket(db_client,
+                                        storage_client,
+                                        config,
+                                        snippets={},
+                                        check_for_presence=False)
 
     self.assertEqual(table.rows, [{}])
 
@@ -104,10 +104,10 @@ class TestImportEntireBucket(unittest.TestCase):
     bucket.register_blob("hello3.json", "")
 
     with contextlib.redirect_stdout(io.StringIO()):
-      import_entire_bucket(db_client,
-                           storage_client,
-                           config,
-                           snippets={},
-                           check_for_presence=False)
+      batch_import.import_entire_bucket(db_client,
+                                        storage_client,
+                                        config,
+                                        snippets={},
+                                        check_for_presence=False)
 
     self.assertEqual(table.rows, [{}, {}, {}])

--- a/devtools/db_import/db_import/batch_import_test.py
+++ b/devtools/db_import/db_import/batch_import_test.py
@@ -1,0 +1,113 @@
+## Copyright 2023 The OpenXLA Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+import contextlib
+import io
+import unittest
+
+from db_import.batch_import import import_entire_bucket
+from db_import import in_memory_storage
+from db_import import in_memory_database
+
+
+class TestImportEntireBucket(unittest.TestCase):
+
+  def test_empty_bucket(self):
+    rule = {"filepath_regex": "\.json$", "result": "{}"}
+    config = {
+        "bucket_name": "random_bucket_name",
+        "rules": [rule],
+        "cloud_function_name": "random_cloud_function_name",
+        "table_name": "random_table_name",
+    }
+
+    db_client = in_memory_database.Client()
+    table = db_client.register_table("random_table_name")
+
+    storage_client = in_memory_storage.Client()
+    storage_client.register_bucket("random_bucket_name")
+
+    import_entire_bucket(db_client,
+                         storage_client,
+                         config,
+                         snippets={},
+                         check_for_presence=False)
+    self.assertEqual(table.rows, [])
+
+  def test_no_match(self):
+    rule = {"filepath_regex": "^unknown\.json$", "result": "{}"}
+    config = {
+        "bucket_name": "random_bucket_name",
+        "rules": [rule],
+        "cloud_function_name": "random_cloud_function_name",
+        "table_name": "random_table_name",
+    }
+
+    db_client = in_memory_database.Client()
+    table = db_client.register_table("random_table_name")
+
+    storage_client = in_memory_storage.Client()
+    storage_client.register_bucket("random_bucket_name").register_blob(
+        "hello.json", "")
+
+    import_entire_bucket(db_client,
+                         storage_client,
+                         config,
+                         snippets={},
+                         check_for_presence=False)
+    self.assertEqual(table.rows, [])
+
+  def test_single_file(self):
+    rule = {"filepath_regex": "^hello\.json$", "result": "{}"}
+    config = {
+        "bucket_name": "random_bucket_name",
+        "rules": [rule],
+        "cloud_function_name": "random_cloud_function_name",
+        "table_name": "random_table_name",
+    }
+
+    db_client = in_memory_database.Client()
+    table = db_client.register_table("random_table_name")
+
+    storage_client = in_memory_storage.Client()
+    storage_client.register_bucket("random_bucket_name").register_blob(
+        "hello.json", "")
+
+    with contextlib.redirect_stdout(io.StringIO()):
+      import_entire_bucket(db_client,
+                           storage_client,
+                           config,
+                           snippets={},
+                           check_for_presence=False)
+
+    self.assertEqual(table.rows, [{}])
+
+  def test_multiple_files(self):
+    rule = {"filepath_regex": "^hello.\.json$", "result": "{}"}
+    config = {
+        "bucket_name": "random_bucket_name",
+        "rules": [rule],
+        "cloud_function_name": "random_cloud_function_name",
+        "table_name": "random_table_name",
+    }
+
+    db_client = in_memory_database.Client()
+    table = db_client.register_table("random_table_name")
+
+    storage_client = in_memory_storage.Client()
+    bucket = storage_client.register_bucket("random_bucket_name")
+    bucket.register_blob("hello1.json", "")
+    bucket.register_blob("hello2.json", "")
+    bucket.register_blob("hello3.json", "")
+
+    with contextlib.redirect_stdout(io.StringIO()):
+      import_entire_bucket(db_client,
+                           storage_client,
+                           config,
+                           snippets={},
+                           check_for_presence=False)
+
+    self.assertEqual(table.rows, [{}, {}, {}])

--- a/devtools/db_import/db_import/db.py
+++ b/devtools/db_import/db_import/db.py
@@ -7,7 +7,7 @@
    Check out in_memory_database for an alternative implementation of these protocols.
 """
 
-from typing import Any, Protocol, Mapping, Optional, Iterable, Union, runtime_checkable
+from typing import Any, Dict, Protocol, Mapping, Optional, Iterable, Union, runtime_checkable
 from google.cloud import bigquery
 
 
@@ -52,7 +52,7 @@ class Client(Protocol):
 def query_returns_non_empty_result(
     client: Client,
     sql: str,
-    parameters: dict[str, str],
+    parameters: Dict[str, str],
 ) -> bool:
   job_config = bigquery.QueryJobConfig(query_parameters=[
       bigquery.ScalarQueryParameter(key, "STRING", value)
@@ -68,7 +68,7 @@ def query_returns_non_empty_result(
   return rows[0].get("count") > 0
 
 
-def delete_all_preexisting_data(client: Client, config: dict[str, Any]):
+def delete_all_preexisting_data(client: Client, config: Dict[str, Any]):
   table = client.get_table(config["table_name"])
 
   job_config = bigquery.QueryJobConfig(query_parameters=[

--- a/devtools/db_import/db_import/db.py
+++ b/devtools/db_import/db_import/db.py
@@ -47,3 +47,38 @@ class Client(Protocol):
 
   def get_table(self, table: Union[str, Table]) -> Table:
     ...
+
+
+def query_returns_non_empty_result(
+    client: Client,
+    sql: str,
+    parameters: dict[str, str],
+) -> bool:
+  job_config = bigquery.QueryJobConfig(query_parameters=[
+      bigquery.ScalarQueryParameter(key, "STRING", value)
+      for key, value in parameters.items()
+  ])
+
+  rows = list(
+      client.query(
+          f"SELECT COUNT(*) as count FROM ({sql})",
+          job_config=job_config,
+      ).result())
+  assert len(rows) == 1
+  return rows[0].get("count") > 0
+
+
+def delete_all_preexisting_data(client: Client, config: dict[str, Any]):
+  table = client.get_table(config["table_name"])
+
+  job_config = bigquery.QueryJobConfig(query_parameters=[
+      bigquery.ScalarQueryParameter("bucket_name", "STRING",
+                                    config["bucket_name"])
+  ])
+
+  sql = config["sql_delete"].format(table=table.table_id,
+                                    dataset=table.dataset_id)
+  client.query(
+      sql,
+      job_config=job_config,
+  ).result()

--- a/devtools/db_import/db_import/in_memory_database.py
+++ b/devtools/db_import/db_import/in_memory_database.py
@@ -49,6 +49,9 @@ class Client:
       self.tables[name] = Table(name)
     return self.tables[name]
 
+  def register_table(self, name: str) -> Table:
+    return self.get_table(name)
+
   def insert_rows(self, table: Union[str, Table], rows: Sequence):
     table_obj = table if isinstance(table, Table) else self.get_table(table)
     table_obj.rows.extend(rows)

--- a/devtools/db_import/db_import/in_memory_storage.py
+++ b/devtools/db_import/db_import/in_memory_storage.py
@@ -28,7 +28,7 @@ class Bucket:
   """
 
   def __init__(self):
-    self.contents: dict[str, str] = {}
+    self.contents: Dict[str, str] = {}
 
   def blob(self, name: str) -> Blob:
     return Blob(name, self, self.contents[name])


### PR DESCRIPTION
This is adding a new tool to the CLI, the batch import.

The batch import can scan through all the files in an existing GCS bucket and trigger the import pipeline as if all those files were just uploaded. It's usually needed when a new pipeline is set up and when we want to import all the existing data.