### PR TITLE
Add download helper tool

### DIFF
--- a/devtools/db_import/cli.py
+++ b/devtools/db_import/cli.py
@@ -11,8 +11,9 @@ import yaml
 
 SCRIPT_DIR = pathlib.Path(__file__).resolve().parent
 
-from db_import.batch_import import configure_parser as configure_batch_import_parser
-from db_import.process import configure_parser as configure_process_parser
+from db_import import download
+from db_import import batch_import
+from db_import import process
 
 parser = argparse.ArgumentParser(prog="cli",
                                  description="Manages the cloud functions")
@@ -26,13 +27,17 @@ parser.add_argument(
 )
 subparsers = parser.add_subparsers(required=True)
 
+download_parser = subparsers.add_parser(
+    "download", help="Download files from bucket for local usage")
+download.configure_parser(download_parser)
+
 batch_import_parser = subparsers.add_parser(
     "batch_import", help="Batch import an entire bucket")
-configure_batch_import_parser(batch_import_parser)
+batch_import.configure_parser(batch_import_parser)
 
 process_parser = subparsers.add_parser(
     "process", help="Process a single file from a bucket")
-configure_process_parser(process_parser)
+process.configure_parser(process_parser)
 
 args = parser.parse_args()
 

--- a/devtools/db_import/db_import/batch_import.py
+++ b/devtools/db_import/db_import/batch_import.py
@@ -6,6 +6,7 @@
 
 import argparse
 import sys
+import pathlib
 
 from google.cloud import bigquery
 from google.cloud import storage
@@ -56,7 +57,7 @@ def import_entire_bucket(
     snippets: Dict[str, str],
     check_for_presence: bool,
     prefix_filter: Optional[str] = None,
-    dump_files_to: Optional[str] = None,
+    dump_files_to: Optional[pathlib.Path] = None,
 ):
   bucket = storage_client.get_bucket(config["bucket_name"])
   table = db_client.get_table(config["table_name"])
@@ -86,7 +87,7 @@ def import_entire_bucket(
       # This happens so often, that we don't wanna clutter the output, so
       # we rather do a carriage return and re-use the same line.
       print("No rule applies.\r" + " " * 250, end="\r")
-    except process.BenchmarkRunAlreadyPresentError:
+    except rules.BenchmarkRunAlreadyPresentError:
       print("Data already present.")
     except Exception as e:
       print("Failure:")

--- a/devtools/db_import/db_import/download.py
+++ b/devtools/db_import/db_import/download.py
@@ -1,0 +1,55 @@
+## Copyright 2023 The OpenXLA Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+import argparse
+import pathlib
+import sys
+
+from google.cloud import storage
+
+from db_import import in_memory_database
+from db_import import batch_import
+
+
+def configure_parser(parser: argparse.ArgumentParser):
+  parser.set_defaults(command_handler=_download)
+  parser.add_argument("config_name")
+  parser.add_argument(
+      "-d",
+      "--destination",
+      help="Directory path where to store the files (default=./testdata)",
+      type=pathlib.Path,
+      default=pathlib.Path('.').resolve() / "testdata",
+  )
+  parser.add_argument(
+      "-p",
+      "--prefix",
+      help="Filter triggering files in bucket by this regular expression",
+  )
+
+
+def _download(config_file, args: argparse.Namespace):
+  try:
+    config = config_file["cloud_functions"][args.config_name]
+  except KeyError:
+    sys.exit(f"No configuration with the name {args.config_name} found.")
+
+  storage_client = storage.Client()
+  db_client = in_memory_database.Client()
+
+  # We are simulating a batch import here, by streaming the results into
+  # the in memory database implementation. In addition we use the
+  # `dump_files_to` which writes each downloaded GCS blob also into a file
+  # on the filesystem. This way we end up with exactly the files we need
+  # to repeat an import locally.
+  batch_import.import_entire_bucket(
+      db_client,
+      storage_client,
+      config,
+      config_file.get("snippets", {}),
+      check_for_presence=False,
+      prefix_filter=args.prefix if args.prefix else None,
+      dump_files_to=args.destination)

--- a/devtools/db_import/db_import/process.py
+++ b/devtools/db_import/db_import/process.py
@@ -7,6 +7,7 @@
 import argparse
 import json
 import sys
+import pathlib
 
 from google.cloud import bigquery, storage as CloudStorage
 from typing import Optional, Any, Callable, Dict, List
@@ -91,7 +92,7 @@ def process_single_file(
     config: Dict,
     snippets: Dict[str, str],
     presence_check: Optional[Callable[[Dict, Dict], bool]] = None,
-    dump_files_to: Optional[str] = None,
+    dump_files_to: Optional[pathlib.Path] = None,
 ) -> List[Any]:
 
   for rule in rules:

--- a/devtools/db_import/db_import/rules.py
+++ b/devtools/db_import/db_import/rules.py
@@ -71,9 +71,9 @@ def apply_rule_to_file(
       contents = fd.read()
 
     if dump_files_to:
-      dump_directory = dump_files_to / config["bucket_name"]
-      dump_directory.mkdir(parents=True, exist_ok=True)
-      (dump_directory / filepath).write_text(contents)
+      full_filepath = dump_files_to / config["bucket_name"] / filepath
+      full_filepath.parent.mkdir(parents=True, exist_ok=True)
+      full_filepath.write_text(contents)
 
     return contents
 

--- a/devtools/db_import/db_import/rules_test.py
+++ b/devtools/db_import/db_import/rules_test.py
@@ -113,14 +113,14 @@ class TestApplyRuleToFile(unittest.TestCase):
     bucket = in_memory_storage.Bucket()
     file1_with_content = bucket.register_blob("hello.json",
                                               "hello.json content")
-    file2_with_content = bucket.register_blob("world.json",
+    file2_with_content = bucket.register_blob("subdirectory/world.json",
                                               "world.json content")
 
     rule = {
         "filepath_regex":
             "hello\.json",
         "result":
-            "std.native('readFile')('hello.json') + std.native('readFile')('world.json')",
+            "std.native('readFile')('hello.json') + std.native('readFile')('subdirectory/world.json')",
     }
 
     with tempfile.TemporaryDirectory() as dir:
@@ -132,7 +132,8 @@ class TestApplyRuleToFile(unittest.TestCase):
       self.assertTrue(path1.is_file())
       self.assertEqual(path1.read_text(), file1_with_content.contents)
 
-      path2 = temp_dir / EMPTY_CONFIG["bucket_name"] / "world.json"
+      path2 = temp_dir / EMPTY_CONFIG[
+          "bucket_name"] / "subdirectory" / "world.json"
       self.assertTrue(path2.is_file())
       self.assertEqual(path2.read_text(), file2_with_content.contents)
 


### PR DESCRIPTION
This is adding a small helper tool to the CLI which allows the user to download all the needed files from a bucket to their local hard drive.

The tool accepts the name of a pipeline configuration as an argument, then gets a list of all the files from the bucket associated with the config. Each file is treated as a trigger to the pipeline, similar to how the batch import works.

The user will end up with a local copy of all the files that are needed to trigger the cloud function locally.

In the example of IREE:
- Benchmark traces would NOT be downloaded because the config leaves those alone
- benchmark-results-*.json files will be downloaded because these are valid triggers of the pipeline
- execution-benchmark-config.json files will ALSO be downloaded because the data transformation step will request those as needed even though they won't trigger an import on its own.