### PR TITLE
[DB Import] Rename cloud_functions config key to pipelines

### DIFF
--- a/devtools/db_import/db_import/batch_import.py
+++ b/devtools/db_import/db_import/batch_import.py
@@ -31,7 +31,7 @@ def configure_parser(parser: argparse.ArgumentParser):
 
 def _batch_import(config_file, args: argparse.Namespace):
   try:
-    config = config_file["cloud_functions"][args.config_name]
+    config = config_file["pipelines"][args.config_name]
   except KeyError:
     sys.exit(f"No configuration with the name {args.config_name} found.")
 

--- a/devtools/db_import/db_import/batch_import.py
+++ b/devtools/db_import/db_import/batch_import.py
@@ -12,6 +12,7 @@ from google.cloud import bigquery
 from google.cloud import storage
 from typing import Optional, Any, Dict
 
+from db_import import config
 from db_import import process
 from db_import import rules
 from db_import import db
@@ -31,7 +32,7 @@ def configure_parser(parser: argparse.ArgumentParser):
 
 def _batch_import(config_file, args: argparse.Namespace):
   try:
-    config = config_file["pipelines"][args.config_name]
+    current_config = config_file[config.PIPELINES_KEY][args.config_name]
   except KeyError:
     sys.exit(f"No configuration with the name {args.config_name} found.")
 
@@ -41,7 +42,7 @@ def _batch_import(config_file, args: argparse.Namespace):
   import_entire_bucket(
       db_client,
       storage_client,
-      config,
+      current_config,
       config_file.get("snippets", {}),
       check_for_presence=args.check,
   )

--- a/devtools/db_import/db_import/config.py
+++ b/devtools/db_import/db_import/config.py
@@ -1,0 +1,7 @@
+## Copyright 2023 The OpenXLA Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+PIPELINES_KEY: str = "pipelines"

--- a/devtools/db_import/db_import/deploy.py
+++ b/devtools/db_import/db_import/deploy.py
@@ -12,6 +12,7 @@ import sys
 
 from google.cloud import storage, bigquery
 
+from db_import import config
 from db_import import batch_import
 from db_import import db
 
@@ -64,10 +65,10 @@ def _deploy(config_file, args: argparse.Namespace):
 
   for config_name in args.config_names:
     print(f"Processing config {config_name}...")
-    config = config_file["pipelines"][config_name]
-    bucket_name = config["bucket_name"]
-    cloud_function_name = config["cloud_function_name"]
-    table_name = config["table_name"]
+    current_config = config_file[config.PIPELINES_KEY][config_name]
+    bucket_name = current_config["bucket_name"]
+    cloud_function_name = current_config["cloud_function_name"]
+    table_name = current_config["table_name"]
     table_exists = bool(bq["show", table_name] & plumbum.TF)
     db_client = bigquery.Client()
 
@@ -91,7 +92,7 @@ def _deploy(config_file, args: argparse.Namespace):
         print(
             f"Deleting pre-existing data from destination table {table_name} as requested."
         )
-        db.delete_all_preexisting_data(db_client, config)
+        db.delete_all_preexisting_data(db_client, current_config)
       else:
         print(
             f"The destination table {table_name} already exists. Checking if data is already present."
@@ -99,8 +100,9 @@ def _deploy(config_file, args: argparse.Namespace):
 
     table = db_client.get_table(table_name)
     data_exists = db.query_returns_non_empty_result(
-        db_client, config["sql_data_present"].format(table=table.table_id,
-                                                     dataset=table.dataset_id),
+        db_client,
+        current_config["sql_data_present"].format(table=table.table_id,
+                                                  dataset=table.dataset_id),
         {"bucket_name": bucket_name})
 
     if not data_exists or args.force_data_import:
@@ -113,7 +115,7 @@ def _deploy(config_file, args: argparse.Namespace):
 
       batch_import.import_entire_bucket(db_client,
                                         storage_client,
-                                        config,
+                                        current_config,
                                         config_file.get("snippets", {}),
                                         check_for_presence=False)
 

--- a/devtools/db_import/db_import/deploy.py
+++ b/devtools/db_import/db_import/deploy.py
@@ -64,7 +64,7 @@ def _deploy(config_file, args: argparse.Namespace):
 
   for config_name in args.config_names:
     print(f"Processing config {config_name}...")
-    config = config_file["cloud_functions"][config_name]
+    config = config_file["pipelines"][config_name]
     bucket_name = config["bucket_name"]
     cloud_function_name = config["cloud_function_name"]
     table_name = config["table_name"]

--- a/devtools/db_import/db_import/download.py
+++ b/devtools/db_import/db_import/download.py
@@ -10,6 +10,7 @@ import sys
 
 from google.cloud import storage
 
+from db_import import config
 from db_import import in_memory_database
 from db_import import batch_import
 
@@ -33,7 +34,7 @@ def configure_parser(parser: argparse.ArgumentParser):
 
 def _download(config_file, args: argparse.Namespace):
   try:
-    config = config_file["pipelines"][args.config_name]
+    current_config = config_file[config.PIPELINES_KEY][args.config_name]
   except KeyError:
     sys.exit(f"No configuration with the name {args.config_name} found.")
 
@@ -48,7 +49,7 @@ def _download(config_file, args: argparse.Namespace):
   batch_import.import_entire_bucket(
       db_client,
       storage_client,
-      config,
+      current_config,
       config_file.get("snippets", {}),
       check_for_presence=False,
       prefix_filter=args.prefix if args.prefix else None,

--- a/devtools/db_import/db_import/download.py
+++ b/devtools/db_import/db_import/download.py
@@ -33,7 +33,7 @@ def configure_parser(parser: argparse.ArgumentParser):
 
 def _download(config_file, args: argparse.Namespace):
   try:
-    config = config_file["cloud_functions"][args.config_name]
+    config = config_file["pipelines"][args.config_name]
   except KeyError:
     sys.exit(f"No configuration with the name {args.config_name} found.")
 

--- a/devtools/db_import/db_import/process.py
+++ b/devtools/db_import/db_import/process.py
@@ -54,7 +54,7 @@ def configure_parser(parser: argparse.ArgumentParser):
 
 def _process(config_file, args: argparse.Namespace):
   try:
-    config = config_file["cloud_functions"][args.config]
+    config = config_file["pipelines"][args.config]
   except KeyError:
     sys.exit(f"No configuration with the name {args.config_name} found.")
 

--- a/devtools/db_import/main.py
+++ b/devtools/db_import/main.py
@@ -15,6 +15,7 @@ import yaml
 from google.cloud import bigquery, storage
 from cloudevents.http import event
 
+from db_import import config
 from db_import import db
 from db_import import process
 
@@ -23,13 +24,13 @@ SCRIPT_DIR = pathlib.Path(__file__).resolve().parent
 with open(SCRIPT_DIR / "config.yml") as fd:
   config_file = yaml.safe_load(fd)
 
-config = config_file["pipelines"][os.environ["config_name"]]
+current_config = config_file[config.PIPELINES_KEY][os.environ["config_name"]]
 
 db_client = bigquery.Client()
-table = db_client.get_table(config["table_name"])
+table = db_client.get_table(current_config["table_name"])
 
 storage_client = storage.Client()
-bucket = storage_client.bucket(config["bucket_name"])
+bucket = storage_client.bucket(current_config["bucket_name"])
 
 
 def presence_check(rule: Dict, parameters: Dict) -> bool:
@@ -46,11 +47,12 @@ def entry_point(event: event.CloudEvent):
   file = bucket.get_blob(event.data["name"])
   if not file:
     raise RuntimeError(
-        f"File {event.data['name']} does not exist in bucket {config['bucket_name']}."
+        f"File {event.data['name']} does not exist in bucket {current_config['bucket_name']}."
     )
 
-  rows = process.process_single_file(config["rules"], file, config,
-                                     config_file["snippets"], presence_check)
+  rows = process.process_single_file(current_config["rules"], file,
+                                     current_config, config_file["snippets"],
+                                     presence_check)
 
   if len(rows) > 0:
     db_client.insert_rows(table, rows)

--- a/devtools/db_import/main.py
+++ b/devtools/db_import/main.py
@@ -23,7 +23,7 @@ SCRIPT_DIR = pathlib.Path(__file__).resolve().parent
 with open(SCRIPT_DIR / "config.yml") as fd:
   config_file = yaml.safe_load(fd)
 
-config = config_file["cloud_functions"][os.environ["config_name"]]
+config = config_file["pipelines"][os.environ["config_name"]]
 
 db_client = bigquery.Client()
 table = db_client.get_table(config["table_name"])


### PR DESCRIPTION
This renames the main config key in the config file from `cloud_functions` to `pipelines` because this will make the usage of terms in the documentation more consistent.

It's because each entry under `pipelines` has the configuration of the full assembly, not just the cloud function. The cloud function is just one aspect of it, that why the docs call it a pipeline.