### PR TITLE
Use anonymous credentials in bigquery emulator

### DIFF
--- a/devtools/db_import/db_import/bigquery_emulator.py
+++ b/devtools/db_import/db_import/bigquery_emulator.py
@@ -10,6 +10,7 @@ import subprocess
 from contextlib import contextmanager, closing
 from typing import Generator
 
+from google.auth import credentials
 from google.cloud import bigquery
 from google.api_core.client_options import ClientOptions
 
@@ -72,7 +73,10 @@ def emulate_bigquery(
   ) as process:
     try:
       client_options = ClientOptions(api_endpoint=f"http://0.0.0.0:{http_port}")
-      yield bigquery.Client(project=project_name, client_options=client_options)
+      anonymous_credentials = credentials.AnonymousCredentials()
+      yield bigquery.Client(project=project_name,
+                            client_options=client_options,
+                            credentials=anonymous_credentials)
     finally:
       process.terminate()
       try:


### PR DESCRIPTION
This is a quick fixup for the bigquery emulator. It explicitly makes the database client use anonymous credentials - which is all we need when connecting to the emulator.

If this was not the case then the client library would try to infer credentials from the user's gcloud config and fail if the user didn't have one.