### PR TITLE
[DB Import] Factor out config loading and add embedding support

### DIFF
--- a/devtools/db_import/.gcloudignore
+++ b/devtools/db_import/.gcloudignore
@@ -14,6 +14,7 @@
 /db_import/*
 !/db_import/*.py
 /db_import/*_test.py
-!/config.yml
+!/*.yml
+!/*.jsonnet
 !/main.py
 !/requirements.txt

--- a/devtools/db_import/cli.py
+++ b/devtools/db_import/cli.py
@@ -7,10 +7,10 @@
 
 import argparse
 import pathlib
-import yaml
 
 SCRIPT_DIR = pathlib.Path(__file__).resolve().parent
 
+from db_import import config
 from db_import import deploy
 from db_import import download
 from db_import import batch_import
@@ -47,6 +47,6 @@ process.configure_parser(process_parser)
 args = parser.parse_args()
 
 with open(args.config_file) as fd:
-  config_file = yaml.safe_load(fd)
+  config_file = config.load_config(fd)
 
 args.command_handler(config_file, args)

--- a/devtools/db_import/db_import/config.py
+++ b/devtools/db_import/db_import/config.py
@@ -4,4 +4,55 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+import pathlib
+import yaml
+import contextlib
+import os
+
+from typing import TextIO
+
 PIPELINES_KEY: str = "pipelines"
+
+
+@contextlib.contextmanager
+def _current_working_directory(path: pathlib.Path):
+  previous_cwd = pathlib.Path().absolute()
+
+  try:
+    os.chdir(path)
+    yield path
+  finally:
+    os.chdir(previous_cwd)
+
+
+def _embed(loader: yaml.Loader, node):
+  """This tag handler allows loading the contents of file as string into a node.
+
+    The initial node's content is interpreted as a file path.
+    Relative file path are expected to be relative to the YAML file's location.
+    Absolute paths are also allowed but must refer to a location below the YAML
+    file's parent directory.
+
+    Example:
+    ```yaml
+    ---
+    property: !embed filename.txt
+    """
+  yaml_filepath = pathlib.Path(loader.name).resolve()
+
+  with _current_working_directory(yaml_filepath.parent):
+    filepath = pathlib.Path(loader.construct_scalar(node)).resolve()
+    allowed_directory = yaml_filepath.parent.resolve()
+    # We use os.path here to check whether filepath is below allowed_directory,
+    # because the equivalent function in pathlib is not available before Python 3.9.
+    assert os.path.commonpath([allowed_directory]) == os.path.commonpath(
+        [allowed_directory, filepath])
+    assert filepath.is_file()
+    return filepath.read_text()
+
+
+yaml.SafeLoader.add_constructor("!embed", _embed)
+
+
+def load_config(file: TextIO):
+  return yaml.safe_load(file)

--- a/devtools/db_import/db_import/config_test.py
+++ b/devtools/db_import/db_import/config_test.py
@@ -1,0 +1,66 @@
+## Copyright 2023 The OpenXLA Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+import io
+import pathlib
+import tempfile
+import unittest
+
+from db_import import config
+
+
+class TestConfig(unittest.TestCase):
+
+  def run(self, result=None):
+    with tempfile.TemporaryDirectory() as directory_path_str:
+      self.directory_path = pathlib.Path(directory_path_str)
+      super(TestConfig, self).run(result)
+
+  def test_load_empty_config(self):
+    fd = io.StringIO("---\n")
+    self.assertEqual(config.load_config(fd), None)
+
+  def test_load_basic_config(self):
+    fd = io.StringIO("---\nkey: value\n")
+    self.assertEqual(config.load_config(fd), {"key": "value"})
+
+  def test_load_config_with_relative_path_embedding(self):
+    with tempfile.TemporaryDirectory() as directory_path_str:
+      directory_path = pathlib.Path(directory_path_str)
+      (directory_path / "file.txt").write_text("42")
+
+      # The embedding feature only works when the YAML is loaded from a file, so no StringIO here:
+      config_file_path = directory_path / "config.yml"
+      config_file_path.write_text("---\nkey: !embed file.txt\n")
+
+      with open(config_file_path) as fd:
+        self.assertEqual(config.load_config(fd), {"key": "42"})
+
+  def test_load_config_with_absolute_path_embedding(self):
+    with tempfile.TemporaryDirectory() as directory_path_str:
+      directory_path = pathlib.Path(directory_path_str)
+      (directory_path / "file.txt").write_text("42")
+
+      # The embedding feature only works when the YAML is loaded from a file, so no StringIO here:
+      config_file_path = directory_path / "config.yml"
+      config_file_path.write_text(
+          f"---\nkey: !embed {directory_path / 'file.txt'}\n")
+
+      with open(config_file_path) as fd:
+        self.assertEqual(config.load_config(fd), {"key": "42"})
+
+  def test_load_config_with_forbidden_path(self):
+    with tempfile.TemporaryDirectory() as directory_path_str:
+      directory_path = pathlib.Path(directory_path_str)
+      (directory_path / "file.txt").write_text("42")
+
+      # The embedding feature only works when the YAML is loaded from a file, so no StringIO here:
+      config_file_path = directory_path / "config.yml"
+      config_file_path.write_text(f"---\nkey: !embed /etc/passwd\n")
+
+      with open(config_file_path) as fd:
+        with self.assertRaises(Exception):
+          config.load_config(fd)

--- a/devtools/db_import/db_import/config_test.py
+++ b/devtools/db_import/db_import/config_test.py
@@ -55,12 +55,22 @@ class TestConfig(unittest.TestCase):
   def test_load_config_with_forbidden_path(self):
     with tempfile.TemporaryDirectory() as directory_path_str:
       directory_path = pathlib.Path(directory_path_str)
-      (directory_path / "file.txt").write_text("42")
 
       # The embedding feature only works when the YAML is loaded from a file, so no StringIO here:
       config_file_path = directory_path / "config.yml"
       config_file_path.write_text(f"---\nkey: !embed /etc/passwd\n")
 
-      with open(config_file_path) as fd:
-        with self.assertRaises(Exception):
-          config.load_config(fd)
+      with open(config_file_path) as fd, self.assertRaises(Exception):
+        config.load_config(fd)
+
+  def test_load_config_with_forbidden_symlink(self):
+    with tempfile.TemporaryDirectory() as directory_path_str:
+      directory_path = pathlib.Path(directory_path_str)
+      (directory_path / "file.txt").symlink_to("/etc/passwd")
+
+      # The embedding feature only works when the YAML is loaded from a file, so no StringIO here:
+      config_file_path = directory_path / "config.yml"
+      config_file_path.write_text(f"---\nkey: !embed file.txt\n")
+
+      with open(config_file_path) as fd, self.assertRaises(Exception):
+        config.load_config(fd)

--- a/devtools/db_import/main.py
+++ b/devtools/db_import/main.py
@@ -10,7 +10,6 @@ import functions_framework
 import os
 import pathlib
 from typing import Dict
-import yaml
 
 from google.cloud import bigquery, storage
 from cloudevents.http import event
@@ -22,7 +21,7 @@ from db_import import process
 SCRIPT_DIR = pathlib.Path(__file__).resolve().parent
 
 with open(SCRIPT_DIR / "config.yml") as fd:
-  config_file = yaml.safe_load(fd)
+  config_file = config.load_config(fd)
 
 current_config = config_file[config.PIPELINES_KEY][os.environ["config_name"]]
 


### PR DESCRIPTION
This is doing 2 things:

1. Instead of calling `yaml.safe_load` in all places where we load the config file, this is now done in a single place behind a function.
2. In addition this introduces the `!embed` YAML tag. It allows loading the contents from a given filepath into an arbitrary YAML node. It's made for simplifying the config file by offloading big chunks of JSONnet code into a separate file.