### PR TITLE
Introduce URL of model artifacts dir

### DIFF
--- a/.github/workflows/run_comparative_benchmark.yml
+++ b/.github/workflows/run_comparative_benchmark.yml
@@ -13,6 +13,7 @@ on:
     # Scheduled to run at 09:00 UTC and 21:00 UTC.
     - cron: '0 09,21 * * *'
   workflow_dispatch:
+  pull_request:
 
 concurrency:
   # A PR number if a pull request and otherwise the commit hash. This cancels
@@ -100,81 +101,81 @@ jobs:
           gcloud storage cp "${XLA_TOOLS_DIR_ARCHIVE}" "${XLA_TOOLS_DIR_GCS_ARTIFACT}"
           echo "xla-tools-dir-gcs-artifact=${XLA_TOOLS_DIR_GCS_ARTIFACT}" >> "${GITHUB_OUTPUT}"
 
-  benchmark_on_a2-highgpu-1g:
-    needs: [setup, build_xla_tools]
-    runs-on:
-      - self-hosted  # must come first
-      - runner-group=${{ needs.setup.outputs.runner-group }}
-      - environment=prod
-      - machine-type=a2-highgpu-1g
-    env:
-      BENCHMARK_GCS_DIR: ${{ needs.setup.outputs.benchmark-gcs-dir }}
-      RESULTS_DIR: results-dir
-      TARGET_DEVICE: a2-highgpu-1g
-      XLA_TOOLS_DIR: ${{ needs.build_xla_tools.outputs.xla-tools-dir }}
-      XLA_TOOLS_DIR_ARCHIVE: ${{ needs.build_xla_tools.outputs.xla-tools-dir-archive }}
-      XLA_TOOLS_DIR_GCS_ARTIFACT: ${{ needs.build_xla_tools.outputs.xla-tools-dir-gcs-artifact }}
-    steps:
-      - name: "Checking out PR repository"
-        uses: actions/checkout@e2f20e631ae6d7dd3b768f56a5d2af784dd54791  # v2.5.0
-      - name: "Setup"
-        id: setup
-        run: |
-          echo "results-gcs-dir=${BENCHMARK_GCS_DIR}/${TARGET_DEVICE}-results" >> "${GITHUB_OUTPUT}"
-          mkdir "${RESULTS_DIR}"
-      - name: "Downloading and unpacking XLA tools"
-        run: |
-          gcloud storage cp "${XLA_TOOLS_DIR_GCS_ARTIFACT}" "${XLA_TOOLS_DIR_ARCHIVE}"
-          tar -xvf "${XLA_TOOLS_DIR_ARCHIVE}"
-      - name: "Benchmarking XLA-HLO:GPU"
-        env:
-          XLA_HLO_RESULTS_JSON: xla-hlo.json
-          RESULTS_GCS_DIR: ${{ steps.setup.outputs.results-gcs-dir }}
-        run: |
-          RESULTS_PATH="${RESULTS_DIR}/${XLA_HLO_RESULTS_JSON}"
-          docker run --gpus all --mount="type=bind,src="${PWD}",target=/work" --workdir="/work" \
-            --env "OOBI_XLA_TOOLS_DIR=${XLA_TOOLS_DIR}" \
-            "gcr.io/iree-oss/openxla-benchmark/cuda11.8-cudnn8.9@sha256:c39107c4160e749b7c4bac18862c6c1b6d56e1aa60644a4fe323e315ffba0a0b" \
-            ./comparative_benchmark/xla_hlo/benchmark_all.sh \
-              "${TARGET_DEVICE}"\
-              "${RESULTS_PATH}"
-          gcloud storage cp "${RESULTS_PATH}" "${RESULTS_GCS_DIR}/"
-      - name: "Benchmarking JAX-XLA:GPU"
-        env:
-          JAX_XLA_RESULTS_JSON: jax-xla.json
-          RESULTS_GCS_DIR: ${{ steps.setup.outputs.results-gcs-dir }}
-        run: |
-          RESULTS_PATH="${RESULTS_DIR}/${JAX_XLA_RESULTS_JSON}"
-          docker run --gpus all --mount="type=bind,src="${PWD}",target=/work" --workdir="/work" \
-            "gcr.io/iree-oss/openxla-benchmark/cuda11.8-cudnn8.9@sha256:c39107c4160e749b7c4bac18862c6c1b6d56e1aa60644a4fe323e315ffba0a0b" \
-            ./comparative_benchmark/jax_xla/benchmark_all.sh \
-              "${TARGET_DEVICE}"\
-              "${RESULTS_PATH}"
-          gcloud storage cp "${RESULTS_PATH}" "${RESULTS_GCS_DIR}/"
-      - name: "Benchmarking TF-XLA:GPU"
-        env:
-          TF_XLA_RESULTS_JSON: tf-xla.json
-          RESULTS_GCS_DIR: ${{ steps.setup.outputs.results-gcs-dir }}
-        run: |
-          RESULTS_PATH="${RESULTS_DIR}/${TF_XLA_RESULTS_JSON}"
-          docker run --gpus all --mount="type=bind,src="${PWD}",target=/work" --workdir="/work" \
-            "gcr.io/iree-oss/openxla-benchmark/cuda11.8-cudnn8.9@sha256:c39107c4160e749b7c4bac18862c6c1b6d56e1aa60644a4fe323e315ffba0a0b" \
-            ./comparative_benchmark/tf_xla/benchmark_all.sh \
-              "${TARGET_DEVICE}"\
-              "${RESULTS_PATH}"
-          gcloud storage cp "${RESULTS_PATH}" "${RESULTS_GCS_DIR}/"
-      - name: "Benchmarking PT-Inductor:GPU"
-        env:
-          PT_INDUCTOR_RESULTS_JSON: pt-inductor.json
-          RESULTS_GCS_DIR: ${{ steps.setup.outputs.results-gcs-dir }}
-        run: |
-          RESULTS_PATH="${RESULTS_DIR}/${PT_INDUCTOR_RESULTS_JSON}"
-          docker run --gpus all --mount="type=bind,src="${PWD}",target=/work" --workdir="/work" \
-            "gcr.io/iree-oss/openxla-benchmark/cuda11.8-cudnn8.9@sha256:c39107c4160e749b7c4bac18862c6c1b6d56e1aa60644a4fe323e315ffba0a0b" \
-            ./comparative_benchmark/pt_inductor/benchmark_all.sh \
-              "${TARGET_DEVICE}"\
-              "${RESULTS_PATH}"
-          gcloud storage cp "${RESULTS_PATH}" "${RESULTS_GCS_DIR}/"
+  # benchmark_on_a2-highgpu-1g:
+  #   needs: [setup, build_xla_tools]
+  #   runs-on:
+  #     - self-hosted  # must come first
+  #     - runner-group=${{ needs.setup.outputs.runner-group }}
+  #     - environment=prod
+  #     - machine-type=a2-highgpu-1g
+  #   env:
+  #     BENCHMARK_GCS_DIR: ${{ needs.setup.outputs.benchmark-gcs-dir }}
+  #     RESULTS_DIR: results-dir
+  #     TARGET_DEVICE: a2-highgpu-1g
+  #     XLA_TOOLS_DIR: ${{ needs.build_xla_tools.outputs.xla-tools-dir }}
+  #     XLA_TOOLS_DIR_ARCHIVE: ${{ needs.build_xla_tools.outputs.xla-tools-dir-archive }}
+  #     XLA_TOOLS_DIR_GCS_ARTIFACT: ${{ needs.build_xla_tools.outputs.xla-tools-dir-gcs-artifact }}
+  #   steps:
+  #     - name: "Checking out PR repository"
+  #       uses: actions/checkout@e2f20e631ae6d7dd3b768f56a5d2af784dd54791  # v2.5.0
+  #     - name: "Setup"
+  #       id: setup
+  #       run: |
+  #         echo "results-gcs-dir=${BENCHMARK_GCS_DIR}/${TARGET_DEVICE}-results" >> "${GITHUB_OUTPUT}"
+  #         mkdir "${RESULTS_DIR}"
+  #     - name: "Downloading and unpacking XLA tools"
+  #       run: |
+  #         gcloud storage cp "${XLA_TOOLS_DIR_GCS_ARTIFACT}" "${XLA_TOOLS_DIR_ARCHIVE}"
+  #         tar -xvf "${XLA_TOOLS_DIR_ARCHIVE}"
+  #     - name: "Benchmarking XLA-HLO:GPU"
+  #       env:
+  #         XLA_HLO_RESULTS_JSON: xla-hlo.json
+  #         RESULTS_GCS_DIR: ${{ steps.setup.outputs.results-gcs-dir }}
+  #       run: |
+  #         RESULTS_PATH="${RESULTS_DIR}/${XLA_HLO_RESULTS_JSON}"
+  #         docker run --gpus all --mount="type=bind,src="${PWD}",target=/work" --workdir="/work" \
+  #           --env "OOBI_XLA_TOOLS_DIR=${XLA_TOOLS_DIR}" \
+  #           "gcr.io/iree-oss/openxla-benchmark/cuda11.8-cudnn8.9@sha256:c39107c4160e749b7c4bac18862c6c1b6d56e1aa60644a4fe323e315ffba0a0b" \
+  #           ./comparative_benchmark/xla_hlo/benchmark_all.sh \
+  #             "${TARGET_DEVICE}"\
+  #             "${RESULTS_PATH}"
+  #         gcloud storage cp "${RESULTS_PATH}" "${RESULTS_GCS_DIR}/"
+  #     - name: "Benchmarking JAX-XLA:GPU"
+  #       env:
+  #         JAX_XLA_RESULTS_JSON: jax-xla.json
+  #         RESULTS_GCS_DIR: ${{ steps.setup.outputs.results-gcs-dir }}
+  #       run: |
+  #         RESULTS_PATH="${RESULTS_DIR}/${JAX_XLA_RESULTS_JSON}"
+  #         docker run --gpus all --mount="type=bind,src="${PWD}",target=/work" --workdir="/work" \
+  #           "gcr.io/iree-oss/openxla-benchmark/cuda11.8-cudnn8.9@sha256:c39107c4160e749b7c4bac18862c6c1b6d56e1aa60644a4fe323e315ffba0a0b" \
+  #           ./comparative_benchmark/jax_xla/benchmark_all.sh \
+  #             "${TARGET_DEVICE}"\
+  #             "${RESULTS_PATH}"
+  #         gcloud storage cp "${RESULTS_PATH}" "${RESULTS_GCS_DIR}/"
+  #     - name: "Benchmarking TF-XLA:GPU"
+  #       env:
+  #         TF_XLA_RESULTS_JSON: tf-xla.json
+  #         RESULTS_GCS_DIR: ${{ steps.setup.outputs.results-gcs-dir }}
+  #       run: |
+  #         RESULTS_PATH="${RESULTS_DIR}/${TF_XLA_RESULTS_JSON}"
+  #         docker run --gpus all --mount="type=bind,src="${PWD}",target=/work" --workdir="/work" \
+  #           "gcr.io/iree-oss/openxla-benchmark/cuda11.8-cudnn8.9@sha256:c39107c4160e749b7c4bac18862c6c1b6d56e1aa60644a4fe323e315ffba0a0b" \
+  #           ./comparative_benchmark/tf_xla/benchmark_all.sh \
+  #             "${TARGET_DEVICE}"\
+  #             "${RESULTS_PATH}"
+  #         gcloud storage cp "${RESULTS_PATH}" "${RESULTS_GCS_DIR}/"
+  #     - name: "Benchmarking PT-Inductor:GPU"
+  #       env:
+  #         PT_INDUCTOR_RESULTS_JSON: pt-inductor.json
+  #         RESULTS_GCS_DIR: ${{ steps.setup.outputs.results-gcs-dir }}
+  #       run: |
+  #         RESULTS_PATH="${RESULTS_DIR}/${PT_INDUCTOR_RESULTS_JSON}"
+  #         docker run --gpus all --mount="type=bind,src="${PWD}",target=/work" --workdir="/work" \
+  #           "gcr.io/iree-oss/openxla-benchmark/cuda11.8-cudnn8.9@sha256:c39107c4160e749b7c4bac18862c6c1b6d56e1aa60644a4fe323e315ffba0a0b" \
+  #           ./comparative_benchmark/pt_inductor/benchmark_all.sh \
+  #             "${TARGET_DEVICE}"\
+  #             "${RESULTS_PATH}"
+  #         gcloud storage cp "${RESULTS_PATH}" "${RESULTS_GCS_DIR}/"
 
   benchmark_on_c2-standard-16:
     needs: [setup, build_xla_tools]

--- a/.github/workflows/run_comparative_benchmark.yml
+++ b/.github/workflows/run_comparative_benchmark.yml
@@ -13,7 +13,6 @@ on:
     # Scheduled to run at 09:00 UTC and 21:00 UTC.
     - cron: '0 09,21 * * *'
   workflow_dispatch:
-  pull_request:
 
 concurrency:
   # A PR number if a pull request and otherwise the commit hash. This cancels
@@ -101,81 +100,81 @@ jobs:
           gcloud storage cp "${XLA_TOOLS_DIR_ARCHIVE}" "${XLA_TOOLS_DIR_GCS_ARTIFACT}"
           echo "xla-tools-dir-gcs-artifact=${XLA_TOOLS_DIR_GCS_ARTIFACT}" >> "${GITHUB_OUTPUT}"
 
-  # benchmark_on_a2-highgpu-1g:
-  #   needs: [setup, build_xla_tools]
-  #   runs-on:
-  #     - self-hosted  # must come first
-  #     - runner-group=${{ needs.setup.outputs.runner-group }}
-  #     - environment=prod
-  #     - machine-type=a2-highgpu-1g
-  #   env:
-  #     BENCHMARK_GCS_DIR: ${{ needs.setup.outputs.benchmark-gcs-dir }}
-  #     RESULTS_DIR: results-dir
-  #     TARGET_DEVICE: a2-highgpu-1g
-  #     XLA_TOOLS_DIR: ${{ needs.build_xla_tools.outputs.xla-tools-dir }}
-  #     XLA_TOOLS_DIR_ARCHIVE: ${{ needs.build_xla_tools.outputs.xla-tools-dir-archive }}
-  #     XLA_TOOLS_DIR_GCS_ARTIFACT: ${{ needs.build_xla_tools.outputs.xla-tools-dir-gcs-artifact }}
-  #   steps:
-  #     - name: "Checking out PR repository"
-  #       uses: actions/checkout@e2f20e631ae6d7dd3b768f56a5d2af784dd54791  # v2.5.0
-  #     - name: "Setup"
-  #       id: setup
-  #       run: |
-  #         echo "results-gcs-dir=${BENCHMARK_GCS_DIR}/${TARGET_DEVICE}-results" >> "${GITHUB_OUTPUT}"
-  #         mkdir "${RESULTS_DIR}"
-  #     - name: "Downloading and unpacking XLA tools"
-  #       run: |
-  #         gcloud storage cp "${XLA_TOOLS_DIR_GCS_ARTIFACT}" "${XLA_TOOLS_DIR_ARCHIVE}"
-  #         tar -xvf "${XLA_TOOLS_DIR_ARCHIVE}"
-  #     - name: "Benchmarking XLA-HLO:GPU"
-  #       env:
-  #         XLA_HLO_RESULTS_JSON: xla-hlo.json
-  #         RESULTS_GCS_DIR: ${{ steps.setup.outputs.results-gcs-dir }}
-  #       run: |
-  #         RESULTS_PATH="${RESULTS_DIR}/${XLA_HLO_RESULTS_JSON}"
-  #         docker run --gpus all --mount="type=bind,src="${PWD}",target=/work" --workdir="/work" \
-  #           --env "OOBI_XLA_TOOLS_DIR=${XLA_TOOLS_DIR}" \
-  #           "gcr.io/iree-oss/openxla-benchmark/cuda11.8-cudnn8.9@sha256:c39107c4160e749b7c4bac18862c6c1b6d56e1aa60644a4fe323e315ffba0a0b" \
-  #           ./comparative_benchmark/xla_hlo/benchmark_all.sh \
-  #             "${TARGET_DEVICE}"\
-  #             "${RESULTS_PATH}"
-  #         gcloud storage cp "${RESULTS_PATH}" "${RESULTS_GCS_DIR}/"
-  #     - name: "Benchmarking JAX-XLA:GPU"
-  #       env:
-  #         JAX_XLA_RESULTS_JSON: jax-xla.json
-  #         RESULTS_GCS_DIR: ${{ steps.setup.outputs.results-gcs-dir }}
-  #       run: |
-  #         RESULTS_PATH="${RESULTS_DIR}/${JAX_XLA_RESULTS_JSON}"
-  #         docker run --gpus all --mount="type=bind,src="${PWD}",target=/work" --workdir="/work" \
-  #           "gcr.io/iree-oss/openxla-benchmark/cuda11.8-cudnn8.9@sha256:c39107c4160e749b7c4bac18862c6c1b6d56e1aa60644a4fe323e315ffba0a0b" \
-  #           ./comparative_benchmark/jax_xla/benchmark_all.sh \
-  #             "${TARGET_DEVICE}"\
-  #             "${RESULTS_PATH}"
-  #         gcloud storage cp "${RESULTS_PATH}" "${RESULTS_GCS_DIR}/"
-  #     - name: "Benchmarking TF-XLA:GPU"
-  #       env:
-  #         TF_XLA_RESULTS_JSON: tf-xla.json
-  #         RESULTS_GCS_DIR: ${{ steps.setup.outputs.results-gcs-dir }}
-  #       run: |
-  #         RESULTS_PATH="${RESULTS_DIR}/${TF_XLA_RESULTS_JSON}"
-  #         docker run --gpus all --mount="type=bind,src="${PWD}",target=/work" --workdir="/work" \
-  #           "gcr.io/iree-oss/openxla-benchmark/cuda11.8-cudnn8.9@sha256:c39107c4160e749b7c4bac18862c6c1b6d56e1aa60644a4fe323e315ffba0a0b" \
-  #           ./comparative_benchmark/tf_xla/benchmark_all.sh \
-  #             "${TARGET_DEVICE}"\
-  #             "${RESULTS_PATH}"
-  #         gcloud storage cp "${RESULTS_PATH}" "${RESULTS_GCS_DIR}/"
-  #     - name: "Benchmarking PT-Inductor:GPU"
-  #       env:
-  #         PT_INDUCTOR_RESULTS_JSON: pt-inductor.json
-  #         RESULTS_GCS_DIR: ${{ steps.setup.outputs.results-gcs-dir }}
-  #       run: |
-  #         RESULTS_PATH="${RESULTS_DIR}/${PT_INDUCTOR_RESULTS_JSON}"
-  #         docker run --gpus all --mount="type=bind,src="${PWD}",target=/work" --workdir="/work" \
-  #           "gcr.io/iree-oss/openxla-benchmark/cuda11.8-cudnn8.9@sha256:c39107c4160e749b7c4bac18862c6c1b6d56e1aa60644a4fe323e315ffba0a0b" \
-  #           ./comparative_benchmark/pt_inductor/benchmark_all.sh \
-  #             "${TARGET_DEVICE}"\
-  #             "${RESULTS_PATH}"
-  #         gcloud storage cp "${RESULTS_PATH}" "${RESULTS_GCS_DIR}/"
+  benchmark_on_a2-highgpu-1g:
+    needs: [setup, build_xla_tools]
+    runs-on:
+      - self-hosted  # must come first
+      - runner-group=${{ needs.setup.outputs.runner-group }}
+      - environment=prod
+      - machine-type=a2-highgpu-1g
+    env:
+      BENCHMARK_GCS_DIR: ${{ needs.setup.outputs.benchmark-gcs-dir }}
+      RESULTS_DIR: results-dir
+      TARGET_DEVICE: a2-highgpu-1g
+      XLA_TOOLS_DIR: ${{ needs.build_xla_tools.outputs.xla-tools-dir }}
+      XLA_TOOLS_DIR_ARCHIVE: ${{ needs.build_xla_tools.outputs.xla-tools-dir-archive }}
+      XLA_TOOLS_DIR_GCS_ARTIFACT: ${{ needs.build_xla_tools.outputs.xla-tools-dir-gcs-artifact }}
+    steps:
+      - name: "Checking out PR repository"
+        uses: actions/checkout@e2f20e631ae6d7dd3b768f56a5d2af784dd54791  # v2.5.0
+      - name: "Setup"
+        id: setup
+        run: |
+          echo "results-gcs-dir=${BENCHMARK_GCS_DIR}/${TARGET_DEVICE}-results" >> "${GITHUB_OUTPUT}"
+          mkdir "${RESULTS_DIR}"
+      - name: "Downloading and unpacking XLA tools"
+        run: |
+          gcloud storage cp "${XLA_TOOLS_DIR_GCS_ARTIFACT}" "${XLA_TOOLS_DIR_ARCHIVE}"
+          tar -xvf "${XLA_TOOLS_DIR_ARCHIVE}"
+      - name: "Benchmarking XLA-HLO:GPU"
+        env:
+          XLA_HLO_RESULTS_JSON: xla-hlo.json
+          RESULTS_GCS_DIR: ${{ steps.setup.outputs.results-gcs-dir }}
+        run: |
+          RESULTS_PATH="${RESULTS_DIR}/${XLA_HLO_RESULTS_JSON}"
+          docker run --gpus all --mount="type=bind,src="${PWD}",target=/work" --workdir="/work" \
+            --env "OOBI_XLA_TOOLS_DIR=${XLA_TOOLS_DIR}" \
+            "gcr.io/iree-oss/openxla-benchmark/cuda11.8-cudnn8.9@sha256:c39107c4160e749b7c4bac18862c6c1b6d56e1aa60644a4fe323e315ffba0a0b" \
+            ./comparative_benchmark/xla_hlo/benchmark_all.sh \
+              "${TARGET_DEVICE}"\
+              "${RESULTS_PATH}"
+          gcloud storage cp "${RESULTS_PATH}" "${RESULTS_GCS_DIR}/"
+      - name: "Benchmarking JAX-XLA:GPU"
+        env:
+          JAX_XLA_RESULTS_JSON: jax-xla.json
+          RESULTS_GCS_DIR: ${{ steps.setup.outputs.results-gcs-dir }}
+        run: |
+          RESULTS_PATH="${RESULTS_DIR}/${JAX_XLA_RESULTS_JSON}"
+          docker run --gpus all --mount="type=bind,src="${PWD}",target=/work" --workdir="/work" \
+            "gcr.io/iree-oss/openxla-benchmark/cuda11.8-cudnn8.9@sha256:c39107c4160e749b7c4bac18862c6c1b6d56e1aa60644a4fe323e315ffba0a0b" \
+            ./comparative_benchmark/jax_xla/benchmark_all.sh \
+              "${TARGET_DEVICE}"\
+              "${RESULTS_PATH}"
+          gcloud storage cp "${RESULTS_PATH}" "${RESULTS_GCS_DIR}/"
+      - name: "Benchmarking TF-XLA:GPU"
+        env:
+          TF_XLA_RESULTS_JSON: tf-xla.json
+          RESULTS_GCS_DIR: ${{ steps.setup.outputs.results-gcs-dir }}
+        run: |
+          RESULTS_PATH="${RESULTS_DIR}/${TF_XLA_RESULTS_JSON}"
+          docker run --gpus all --mount="type=bind,src="${PWD}",target=/work" --workdir="/work" \
+            "gcr.io/iree-oss/openxla-benchmark/cuda11.8-cudnn8.9@sha256:c39107c4160e749b7c4bac18862c6c1b6d56e1aa60644a4fe323e315ffba0a0b" \
+            ./comparative_benchmark/tf_xla/benchmark_all.sh \
+              "${TARGET_DEVICE}"\
+              "${RESULTS_PATH}"
+          gcloud storage cp "${RESULTS_PATH}" "${RESULTS_GCS_DIR}/"
+      - name: "Benchmarking PT-Inductor:GPU"
+        env:
+          PT_INDUCTOR_RESULTS_JSON: pt-inductor.json
+          RESULTS_GCS_DIR: ${{ steps.setup.outputs.results-gcs-dir }}
+        run: |
+          RESULTS_PATH="${RESULTS_DIR}/${PT_INDUCTOR_RESULTS_JSON}"
+          docker run --gpus all --mount="type=bind,src="${PWD}",target=/work" --workdir="/work" \
+            "gcr.io/iree-oss/openxla-benchmark/cuda11.8-cudnn8.9@sha256:c39107c4160e749b7c4bac18862c6c1b6d56e1aa60644a4fe323e315ffba0a0b" \
+            ./comparative_benchmark/pt_inductor/benchmark_all.sh \
+              "${TARGET_DEVICE}"\
+              "${RESULTS_PATH}"
+          gcloud storage cp "${RESULTS_PATH}" "${RESULTS_GCS_DIR}/"
 
   benchmark_on_c2-standard-16:
     needs: [setup, build_xla_tools]

--- a/common_benchmark_suite/openxla/benchmark/comparative_suite/jax/model_definitions.py
+++ b/common_benchmark_suite/openxla/benchmark/comparative_suite/jax/model_definitions.py
@@ -11,6 +11,7 @@ from openxla.benchmark import def_types
 from openxla.benchmark.comparative_suite import utils
 
 PARENT_GCS_DIR = "https://storage.googleapis.com/iree-model-artifacts/jax/jax_models_0.4.13_1688607404/"
+ARTIFACTS_URL_TEMPLATE = string.Template(PARENT_GCS_DIR + "${name}")
 
 T5_JAX_IMPL = def_types.ModelImplementation(
     name="T5_JAX",
@@ -31,24 +32,11 @@ T5_LARGE_FP32_JAX_512XI32_BATCH_TEMPLATE = utils.ModelTemplate(
         "model_name": "t5-large",
         "seq_len": 512,
     },
-    artifacts={
-        def_types.ModelArtifactType.STABLEHLO_MLIR:
-            utils.ModelArtifactTemplate(
-                artifact_type=def_types.ModelArtifactType.STABLEHLO_MLIR,
-                source_url=string.Template(
-                    PARENT_GCS_DIR +
-                    "T5_LARGE_FP32_JAX_512XI32_BATCH${batch_size}/stablehlo.mlirbc"
-                ),
-            ),
-        def_types.ModelArtifactType.XLA_HLO_DUMP:
-            utils.ModelArtifactTemplate(
-                artifact_type=def_types.ModelArtifactType.XLA_HLO_DUMP,
-                source_url=string.Template(
-                    PARENT_GCS_DIR +
-                    "T5_LARGE_FP32_JAX_512XI32_BATCH${batch_size}/xla_hlo_before_optimizations.txt"
-                ),
-            ),
-    },
+    artifacts_url=ARTIFACTS_URL_TEMPLATE,
+    exported_model_types=[
+        def_types.ModelArtifactType.STABLEHLO_MLIR,
+        def_types.ModelArtifactType.XLA_HLO_DUMP,
+    ],
 )
 T5_LARGE_FP16_JAX_512XI32_BATCH_TEMPLATE = utils.ModelTemplate(
     name=utils.BATCH_NAME("T5_LARGE_FP16_JAX_512XI32"),
@@ -59,24 +47,11 @@ T5_LARGE_FP16_JAX_512XI32_BATCH_TEMPLATE = utils.ModelTemplate(
         "data_type": "fp16",
         "model_name": "t5-large",
     },
-    artifacts={
-        def_types.ModelArtifactType.STABLEHLO_MLIR:
-            utils.ModelArtifactTemplate(
-                artifact_type=def_types.ModelArtifactType.STABLEHLO_MLIR,
-                source_url=string.Template(
-                    PARENT_GCS_DIR +
-                    "T5_LARGE_FP16_JAX_512XI32_BATCH${batch_size}/stablehlo.mlirbc"
-                ),
-            ),
-        def_types.ModelArtifactType.XLA_HLO_DUMP:
-            utils.ModelArtifactTemplate(
-                artifact_type=def_types.ModelArtifactType.XLA_HLO_DUMP,
-                source_url=string.Template(
-                    PARENT_GCS_DIR +
-                    "T5_LARGE_FP16_JAX_512XI32_BATCH${batch_size}/xla_hlo_before_optimizations.txt"
-                ),
-            ),
-    },
+    artifacts_url=ARTIFACTS_URL_TEMPLATE,
+    exported_model_types=[
+        def_types.ModelArtifactType.STABLEHLO_MLIR,
+        def_types.ModelArtifactType.XLA_HLO_DUMP,
+    ],
 )
 T5_LARGE_BF16_JAX_512XI32_BATCH_TEMPLATE = utils.ModelTemplate(
     name=utils.BATCH_NAME("T5_LARGE_BF16_JAX_512XI32"),
@@ -87,24 +62,11 @@ T5_LARGE_BF16_JAX_512XI32_BATCH_TEMPLATE = utils.ModelTemplate(
         "data_type": "bf16",
         "model_name": "t5-large",
     },
-    artifacts={
-        def_types.ModelArtifactType.STABLEHLO_MLIR:
-            utils.ModelArtifactTemplate(
-                artifact_type=def_types.ModelArtifactType.STABLEHLO_MLIR,
-                source_url=string.Template(
-                    PARENT_GCS_DIR +
-                    "T5_LARGE_BF16_JAX_512XI32_BATCH${batch_size}/stablehlo.mlirbc"
-                ),
-            ),
-        def_types.ModelArtifactType.XLA_HLO_DUMP:
-            utils.ModelArtifactTemplate(
-                artifact_type=def_types.ModelArtifactType.XLA_HLO_DUMP,
-                source_url=string.Template(
-                    PARENT_GCS_DIR +
-                    "T5_LARGE_BF16_JAX_512XI32_BATCH${batch_size}/xla_hlo_before_optimizations.txt"
-                ),
-            ),
-    },
+    artifacts_url=ARTIFACTS_URL_TEMPLATE,
+    exported_model_types=[
+        def_types.ModelArtifactType.STABLEHLO_MLIR,
+        def_types.ModelArtifactType.XLA_HLO_DUMP,
+    ],
 )
 # TODO(#54): Template should also support data types so we don't need to define
 # for each data types.
@@ -140,24 +102,11 @@ T5_4CG_LARGE_FP32_JAX_512XI32_BATCH_TEMPLATE = utils.ModelTemplate(
         "model_name": "t5-large",
         "seq_len": 512
     },
-    artifacts={
-        def_types.ModelArtifactType.STABLEHLO_MLIR:
-            utils.ModelArtifactTemplate(
-                artifact_type=def_types.ModelArtifactType.STABLEHLO_MLIR,
-                source_url=string.Template(
-                    PARENT_GCS_DIR +
-                    "T5_4CG_LARGE_FP32_JAX_512XI32_BATCH${batch_size}/stablehlo.mlirbc"
-                ),
-            ),
-        def_types.ModelArtifactType.XLA_HLO_DUMP:
-            utils.ModelArtifactTemplate(
-                artifact_type=def_types.ModelArtifactType.XLA_HLO_DUMP,
-                source_url=string.Template(
-                    PARENT_GCS_DIR +
-                    "T5_4CG_LARGE_FP32_JAX_512XI32_BATCH${batch_size}/xla_hlo_before_optimizations.txt"
-                ),
-            ),
-    },
+    artifacts_url=ARTIFACTS_URL_TEMPLATE,
+    exported_model_types=[
+        def_types.ModelArtifactType.STABLEHLO_MLIR,
+        def_types.ModelArtifactType.XLA_HLO_DUMP,
+    ],
 )
 T5_4CG_LARGE_FP32_JAX_512XI32_BATCHES = utils.build_batch_models(
     template=T5_4CG_LARGE_FP32_JAX_512XI32_BATCH_TEMPLATE,
@@ -185,24 +134,12 @@ BERT_LARGE_FP32_JAX_384XI32_BATCH_TEMPLATE = utils.ModelTemplate(
         "seq_len": 384,
         "model_name": "bert-large-uncased",
     },
-    artifacts={
-        def_types.ModelArtifactType.STABLEHLO_MLIR:
-            utils.ModelArtifactTemplate(
-                artifact_type=def_types.ModelArtifactType.STABLEHLO_MLIR,
-                source_url=string.Template(
-                    PARENT_GCS_DIR +
-                    "BERT_LARGE_FP32_JAX_384XI32_BATCH${batch_size}/stablehlo.mlirbc"
-                ),
-            ),
-        def_types.ModelArtifactType.XLA_HLO_DUMP:
-            utils.ModelArtifactTemplate(
-                artifact_type=def_types.ModelArtifactType.XLA_HLO_DUMP,
-                source_url=string.Template(
-                    PARENT_GCS_DIR +
-                    "BERT_LARGE_FP32_JAX_384XI32_BATCH${batch_size}/xla_hlo_before_optimizations.txt"
-                ),
-            ),
-    })
+    artifacts_url=ARTIFACTS_URL_TEMPLATE,
+    exported_model_types=[
+        def_types.ModelArtifactType.STABLEHLO_MLIR,
+        def_types.ModelArtifactType.XLA_HLO_DUMP,
+    ],
+)
 
 BERT_LARGE_FP16_JAX_384XI32_BATCH_TEMPLATE = utils.ModelTemplate(
     name=utils.BATCH_NAME("BERT_LARGE_FP16_JAX_384XI32"),
@@ -214,24 +151,12 @@ BERT_LARGE_FP16_JAX_384XI32_BATCH_TEMPLATE = utils.ModelTemplate(
         "seq_len": 384,
         "model_name": "bert-large-uncased",
     },
-    artifacts={
-        def_types.ModelArtifactType.STABLEHLO_MLIR:
-            utils.ModelArtifactTemplate(
-                artifact_type=def_types.ModelArtifactType.STABLEHLO_MLIR,
-                source_url=string.Template(
-                    PARENT_GCS_DIR +
-                    "BERT_LARGE_FP16_JAX_384XI32_BATCH${batch_size}/stablehlo.mlirbc"
-                ),
-            ),
-        def_types.ModelArtifactType.XLA_HLO_DUMP:
-            utils.ModelArtifactTemplate(
-                artifact_type=def_types.ModelArtifactType.XLA_HLO_DUMP,
-                source_url=string.Template(
-                    PARENT_GCS_DIR +
-                    "BERT_LARGE_FP16_JAX_384XI32_BATCH${batch_size}/xla_hlo_before_optimizations.txt"
-                ),
-            ),
-    })
+    artifacts_url=ARTIFACTS_URL_TEMPLATE,
+    exported_model_types=[
+        def_types.ModelArtifactType.STABLEHLO_MLIR,
+        def_types.ModelArtifactType.XLA_HLO_DUMP,
+    ],
+)
 
 BERT_LARGE_BF16_JAX_384XI32_BATCH_TEMPLATE = utils.ModelTemplate(
     name=utils.BATCH_NAME("BERT_LARGE_BF16_JAX_384XI32"),
@@ -243,24 +168,12 @@ BERT_LARGE_BF16_JAX_384XI32_BATCH_TEMPLATE = utils.ModelTemplate(
         "seq_len": 384,
         "model_name": "bert-large-uncased",
     },
-    artifacts={
-        def_types.ModelArtifactType.STABLEHLO_MLIR:
-            utils.ModelArtifactTemplate(
-                artifact_type=def_types.ModelArtifactType.STABLEHLO_MLIR,
-                source_url=string.Template(
-                    PARENT_GCS_DIR +
-                    "BERT_LARGE_BF16_JAX_384XI32_BATCH${batch_size}/stablehlo.mlirbc"
-                ),
-            ),
-        def_types.ModelArtifactType.XLA_HLO_DUMP:
-            utils.ModelArtifactTemplate(
-                artifact_type=def_types.ModelArtifactType.XLA_HLO_DUMP,
-                source_url=string.Template(
-                    PARENT_GCS_DIR +
-                    "BERT_LARGE_BF16_JAX_384XI32_BATCH${batch_size}/xla_hlo_before_optimizations.txt"
-                ),
-            ),
-    })
+    artifacts_url=ARTIFACTS_URL_TEMPLATE,
+    exported_model_types=[
+        def_types.ModelArtifactType.STABLEHLO_MLIR,
+        def_types.ModelArtifactType.XLA_HLO_DUMP,
+    ],
+)
 
 BERT_LARGE_FP32_JAX_384XI32_BATCHES = utils.build_batch_models(
     template=BERT_LARGE_FP32_JAX_384XI32_BATCH_TEMPLATE,
@@ -296,24 +209,12 @@ RESNET50_FP32_JAX_3X224X224XF32_BATCH_TEMPLATE = utils.ModelTemplate(
         "data_type": "fp32",
         "model_name": "microsoft/resnet-50",
     },
-    artifacts={
-        def_types.ModelArtifactType.STABLEHLO_MLIR:
-            utils.ModelArtifactTemplate(
-                artifact_type=def_types.ModelArtifactType.STABLEHLO_MLIR,
-                source_url=string.Template(
-                    PARENT_GCS_DIR +
-                    "RESNET50_FP32_JAX_3X224X224XF32_BATCH${batch_size}/stablehlo.mlirbc"
-                ),
-            ),
-        def_types.ModelArtifactType.XLA_HLO_DUMP:
-            utils.ModelArtifactTemplate(
-                artifact_type=def_types.ModelArtifactType.XLA_HLO_DUMP,
-                source_url=string.Template(
-                    PARENT_GCS_DIR +
-                    "RESNET50_FP32_JAX_3X224X224XF32_BATCH${batch_size}/xla_hlo_before_optimizations.txt"
-                ),
-            ),
-    })
+    artifacts_url=ARTIFACTS_URL_TEMPLATE,
+    exported_model_types=[
+        def_types.ModelArtifactType.STABLEHLO_MLIR,
+        def_types.ModelArtifactType.XLA_HLO_DUMP,
+    ],
+)
 
 RESNET50_FP16_JAX_3X224X224XF16_BATCH_TEMPLATE = utils.ModelTemplate(
     name=utils.BATCH_NAME("RESNET50_FP16_JAX_3X224X224XF16"),
@@ -324,24 +225,12 @@ RESNET50_FP16_JAX_3X224X224XF16_BATCH_TEMPLATE = utils.ModelTemplate(
         "data_type": "fp16",
         "model_name": "microsoft/resnet-50",
     },
-    artifacts={
-        def_types.ModelArtifactType.STABLEHLO_MLIR:
-            utils.ModelArtifactTemplate(
-                artifact_type=def_types.ModelArtifactType.STABLEHLO_MLIR,
-                source_url=string.Template(
-                    PARENT_GCS_DIR +
-                    "RESNET50_FP16_JAX_3X224X224XF16_BATCH${batch_size}/stablehlo.mlirbc"
-                ),
-            ),
-        def_types.ModelArtifactType.XLA_HLO_DUMP:
-            utils.ModelArtifactTemplate(
-                artifact_type=def_types.ModelArtifactType.XLA_HLO_DUMP,
-                source_url=string.Template(
-                    PARENT_GCS_DIR +
-                    "RESNET50_FP16_JAX_3X224X224XF16_BATCH${batch_size}/xla_hlo_before_optimizations.txt"
-                ),
-            ),
-    })
+    artifacts_url=ARTIFACTS_URL_TEMPLATE,
+    exported_model_types=[
+        def_types.ModelArtifactType.STABLEHLO_MLIR,
+        def_types.ModelArtifactType.XLA_HLO_DUMP,
+    ],
+)
 
 RESNET50_BF16_JAX_3X224X224XBF16_BATCH_TEMPLATE = utils.ModelTemplate(
     name=utils.BATCH_NAME("RESNET50_BF16_JAX_3X224X224XBF16"),
@@ -352,24 +241,12 @@ RESNET50_BF16_JAX_3X224X224XBF16_BATCH_TEMPLATE = utils.ModelTemplate(
         "data_type": "bf16",
         "model_name": "microsoft/resnet-50",
     },
-    artifacts={
-        def_types.ModelArtifactType.STABLEHLO_MLIR:
-            utils.ModelArtifactTemplate(
-                artifact_type=def_types.ModelArtifactType.STABLEHLO_MLIR,
-                source_url=string.Template(
-                    PARENT_GCS_DIR +
-                    "RESNET50_BF16_JAX_3X224X224XBF16_BATCH${batch_size}/stablehlo.mlirbc"
-                ),
-            ),
-        def_types.ModelArtifactType.XLA_HLO_DUMP:
-            utils.ModelArtifactTemplate(
-                artifact_type=def_types.ModelArtifactType.XLA_HLO_DUMP,
-                source_url=string.Template(
-                    PARENT_GCS_DIR +
-                    "RESNET50_BF16_JAX_3X224X224XBF16_BATCH${batch_size}/xla_hlo_before_optimizations.txt"
-                ),
-            ),
-    })
+    artifacts_url=ARTIFACTS_URL_TEMPLATE,
+    exported_model_types=[
+        def_types.ModelArtifactType.STABLEHLO_MLIR,
+        def_types.ModelArtifactType.XLA_HLO_DUMP,
+    ],
+)
 
 RESNET50_FP32_JAX_3X224X224XF32_BATCHES = utils.build_batch_models(
     template=RESNET50_FP32_JAX_3X224X224XF32_BATCH_TEMPLATE,

--- a/common_benchmark_suite/openxla/benchmark/comparative_suite/jax/model_definitions.py
+++ b/common_benchmark_suite/openxla/benchmark/comparative_suite/jax/model_definitions.py
@@ -11,7 +11,7 @@ from openxla.benchmark import def_types
 from openxla.benchmark.comparative_suite import utils
 
 PARENT_GCS_DIR = "https://storage.googleapis.com/iree-model-artifacts/jax/jax_models_0.4.13_1688607404/"
-ARTIFACTS_URL_TEMPLATE = string.Template(PARENT_GCS_DIR + "${name}")
+ARTIFACTS_DIR_URL_TEMPLATE = string.Template(PARENT_GCS_DIR + "${name}")
 
 T5_JAX_IMPL = def_types.ModelImplementation(
     name="T5_JAX",
@@ -32,7 +32,7 @@ T5_LARGE_FP32_JAX_512XI32_BATCH_TEMPLATE = utils.ModelTemplate(
         "model_name": "t5-large",
         "seq_len": 512,
     },
-    artifacts_url=ARTIFACTS_URL_TEMPLATE,
+    artifacts_dir_url=ARTIFACTS_DIR_URL_TEMPLATE,
     exported_model_types=[
         def_types.ModelArtifactType.STABLEHLO_MLIR,
         def_types.ModelArtifactType.XLA_HLO_DUMP,
@@ -47,7 +47,7 @@ T5_LARGE_FP16_JAX_512XI32_BATCH_TEMPLATE = utils.ModelTemplate(
         "data_type": "fp16",
         "model_name": "t5-large",
     },
-    artifacts_url=ARTIFACTS_URL_TEMPLATE,
+    artifacts_dir_url=ARTIFACTS_DIR_URL_TEMPLATE,
     exported_model_types=[
         def_types.ModelArtifactType.STABLEHLO_MLIR,
         def_types.ModelArtifactType.XLA_HLO_DUMP,
@@ -62,7 +62,7 @@ T5_LARGE_BF16_JAX_512XI32_BATCH_TEMPLATE = utils.ModelTemplate(
         "data_type": "bf16",
         "model_name": "t5-large",
     },
-    artifacts_url=ARTIFACTS_URL_TEMPLATE,
+    artifacts_dir_url=ARTIFACTS_DIR_URL_TEMPLATE,
     exported_model_types=[
         def_types.ModelArtifactType.STABLEHLO_MLIR,
         def_types.ModelArtifactType.XLA_HLO_DUMP,
@@ -102,7 +102,7 @@ T5_4CG_LARGE_FP32_JAX_512XI32_BATCH_TEMPLATE = utils.ModelTemplate(
         "model_name": "t5-large",
         "seq_len": 512
     },
-    artifacts_url=ARTIFACTS_URL_TEMPLATE,
+    artifacts_dir_url=ARTIFACTS_DIR_URL_TEMPLATE,
     exported_model_types=[
         def_types.ModelArtifactType.STABLEHLO_MLIR,
         def_types.ModelArtifactType.XLA_HLO_DUMP,
@@ -134,7 +134,7 @@ BERT_LARGE_FP32_JAX_384XI32_BATCH_TEMPLATE = utils.ModelTemplate(
         "seq_len": 384,
         "model_name": "bert-large-uncased",
     },
-    artifacts_url=ARTIFACTS_URL_TEMPLATE,
+    artifacts_dir_url=ARTIFACTS_DIR_URL_TEMPLATE,
     exported_model_types=[
         def_types.ModelArtifactType.STABLEHLO_MLIR,
         def_types.ModelArtifactType.XLA_HLO_DUMP,
@@ -151,7 +151,7 @@ BERT_LARGE_FP16_JAX_384XI32_BATCH_TEMPLATE = utils.ModelTemplate(
         "seq_len": 384,
         "model_name": "bert-large-uncased",
     },
-    artifacts_url=ARTIFACTS_URL_TEMPLATE,
+    artifacts_dir_url=ARTIFACTS_DIR_URL_TEMPLATE,
     exported_model_types=[
         def_types.ModelArtifactType.STABLEHLO_MLIR,
         def_types.ModelArtifactType.XLA_HLO_DUMP,
@@ -168,7 +168,7 @@ BERT_LARGE_BF16_JAX_384XI32_BATCH_TEMPLATE = utils.ModelTemplate(
         "seq_len": 384,
         "model_name": "bert-large-uncased",
     },
-    artifacts_url=ARTIFACTS_URL_TEMPLATE,
+    artifacts_dir_url=ARTIFACTS_DIR_URL_TEMPLATE,
     exported_model_types=[
         def_types.ModelArtifactType.STABLEHLO_MLIR,
         def_types.ModelArtifactType.XLA_HLO_DUMP,
@@ -209,7 +209,7 @@ RESNET50_FP32_JAX_3X224X224XF32_BATCH_TEMPLATE = utils.ModelTemplate(
         "data_type": "fp32",
         "model_name": "microsoft/resnet-50",
     },
-    artifacts_url=ARTIFACTS_URL_TEMPLATE,
+    artifacts_dir_url=ARTIFACTS_DIR_URL_TEMPLATE,
     exported_model_types=[
         def_types.ModelArtifactType.STABLEHLO_MLIR,
         def_types.ModelArtifactType.XLA_HLO_DUMP,
@@ -225,7 +225,7 @@ RESNET50_FP16_JAX_3X224X224XF16_BATCH_TEMPLATE = utils.ModelTemplate(
         "data_type": "fp16",
         "model_name": "microsoft/resnet-50",
     },
-    artifacts_url=ARTIFACTS_URL_TEMPLATE,
+    artifacts_dir_url=ARTIFACTS_DIR_URL_TEMPLATE,
     exported_model_types=[
         def_types.ModelArtifactType.STABLEHLO_MLIR,
         def_types.ModelArtifactType.XLA_HLO_DUMP,
@@ -241,7 +241,7 @@ RESNET50_BF16_JAX_3X224X224XBF16_BATCH_TEMPLATE = utils.ModelTemplate(
         "data_type": "bf16",
         "model_name": "microsoft/resnet-50",
     },
-    artifacts_url=ARTIFACTS_URL_TEMPLATE,
+    artifacts_dir_url=ARTIFACTS_DIR_URL_TEMPLATE,
     exported_model_types=[
         def_types.ModelArtifactType.STABLEHLO_MLIR,
         def_types.ModelArtifactType.XLA_HLO_DUMP,

--- a/common_benchmark_suite/openxla/benchmark/comparative_suite/pt/model_definitions.py
+++ b/common_benchmark_suite/openxla/benchmark/comparative_suite/pt/model_definitions.py
@@ -11,6 +11,7 @@ from openxla.benchmark import def_types
 from openxla.benchmark.comparative_suite import utils
 
 PARENT_GCS_DIR = "https://storage.googleapis.com/iree-model-artifacts/pytorch/pt_models_20230709.894_1688992116/"
+ARTIFACTS_URL_TEMPLATE = string.Template(PARENT_GCS_DIR + "${name}")
 
 # Bert models.
 # Model implementation from https://huggingface.co/docs/transformers/model_doc/bert#transformers.BertModel.
@@ -36,16 +37,12 @@ BERT_LARGE_FP32_PT_384XI32_BATCH_TEMPLATE = utils.ModelTemplate(
         "import_on_gpu": False,
         "import_with_fx": True,
     },
-    artifacts={
-        def_types.ModelArtifactType.LINALG_MLIR:
-            utils.ModelArtifactTemplate(
-                artifact_type=def_types.ModelArtifactType.STABLEHLO_MLIR,
-                source_url=string.Template(
-                    PARENT_GCS_DIR +
-                    "BERT_LARGE_FP32_PT_384XI32_BATCH${batch_size}/linalg.mlirbc"
-                ),
-            ),
-    })
+    artifacts_url=ARTIFACTS_URL_TEMPLATE,
+    exported_model_types=[
+        def_types.ModelArtifactType.STABLEHLO_MLIR,
+        def_types.ModelArtifactType.XLA_HLO_DUMP,
+    ],
+)
 
 BERT_LARGE_FP16_PT_384XI32_BATCH_TEMPLATE = utils.ModelTemplate(
     name=utils.BATCH_NAME("BERT_LARGE_FP16_PT_384XI32"),
@@ -59,16 +56,12 @@ BERT_LARGE_FP16_PT_384XI32_BATCH_TEMPLATE = utils.ModelTemplate(
         "import_on_gpu": True,
         "import_with_fx": True,
     },
-    artifacts={
-        def_types.ModelArtifactType.LINALG_MLIR:
-            utils.ModelArtifactTemplate(
-                artifact_type=def_types.ModelArtifactType.STABLEHLO_MLIR,
-                source_url=string.Template(
-                    PARENT_GCS_DIR +
-                    "BERT_LARGE_FP16_PT_384XI32_BATCH${batch_size}/linalg.mlirbc"
-                ),
-            ),
-    })
+    artifacts_url=ARTIFACTS_URL_TEMPLATE,
+    exported_model_types=[
+        def_types.ModelArtifactType.STABLEHLO_MLIR,
+        def_types.ModelArtifactType.XLA_HLO_DUMP,
+    ],
+)
 
 BERT_LARGE_FP32_PT_384XI32_BATCHES = utils.build_batch_models(
     template=BERT_LARGE_FP32_PT_384XI32_BATCH_TEMPLATE,
@@ -99,16 +92,12 @@ RESNET50_FP32_PT_3X224X224XF32_BATCH_TEMPLATE = utils.ModelTemplate(
         "import_on_gpu": False,
         "import_with_fx": True,
     },
-    artifacts={
-        def_types.ModelArtifactType.LINALG_MLIR:
-            utils.ModelArtifactTemplate(
-                artifact_type=def_types.ModelArtifactType.STABLEHLO_MLIR,
-                source_url=string.Template(
-                    PARENT_GCS_DIR +
-                    "RESNET50_FP32_PT_3X224X224XF32_BATCH${batch_size}/linalg.mlirbc"
-                ),
-            ),
-    })
+    artifacts_url=ARTIFACTS_URL_TEMPLATE,
+    exported_model_types=[
+        def_types.ModelArtifactType.STABLEHLO_MLIR,
+        def_types.ModelArtifactType.XLA_HLO_DUMP,
+    ],
+)
 RESNET50_FP16_PT_3X224X224XF16_BATCH_TEMPLATE = utils.ModelTemplate(
     name=utils.BATCH_NAME("RESNET50_FP16_PT_3X224X224XF16"),
     tags=[utils.BATCH_TAG],
@@ -120,16 +109,12 @@ RESNET50_FP16_PT_3X224X224XF16_BATCH_TEMPLATE = utils.ModelTemplate(
         "import_on_gpu": True,
         "import_with_fx": False,
     },
-    artifacts={
-        def_types.ModelArtifactType.LINALG_MLIR:
-            utils.ModelArtifactTemplate(
-                artifact_type=def_types.ModelArtifactType.STABLEHLO_MLIR,
-                source_url=string.Template(
-                    PARENT_GCS_DIR +
-                    "RESNET50_FP16_PT_3X224X224XF16_BATCH${batch_size}/linalg.mlirbc"
-                ),
-            ),
-    })
+    artifacts_url=ARTIFACTS_URL_TEMPLATE,
+    exported_model_types=[
+        def_types.ModelArtifactType.STABLEHLO_MLIR,
+        def_types.ModelArtifactType.XLA_HLO_DUMP,
+    ],
+)
 
 RESNET50_FP32_PT_3X224X224XF32_BATCHES = utils.build_batch_models(
     template=RESNET50_FP32_PT_3X224X224XF32_BATCH_TEMPLATE,

--- a/common_benchmark_suite/openxla/benchmark/comparative_suite/pt/model_definitions.py
+++ b/common_benchmark_suite/openxla/benchmark/comparative_suite/pt/model_definitions.py
@@ -11,7 +11,7 @@ from openxla.benchmark import def_types
 from openxla.benchmark.comparative_suite import utils
 
 PARENT_GCS_DIR = "https://storage.googleapis.com/iree-model-artifacts/pytorch/pt_models_20230709.894_1688992116/"
-ARTIFACTS_URL_TEMPLATE = string.Template(PARENT_GCS_DIR + "${name}")
+ARTIFACTS_DIR_URL_TEMPLATE = string.Template(PARENT_GCS_DIR + "${name}")
 
 # Bert models.
 # Model implementation from https://huggingface.co/docs/transformers/model_doc/bert#transformers.BertModel.
@@ -37,7 +37,7 @@ BERT_LARGE_FP32_PT_384XI32_BATCH_TEMPLATE = utils.ModelTemplate(
         "import_on_gpu": False,
         "import_with_fx": True,
     },
-    artifacts_url=ARTIFACTS_URL_TEMPLATE,
+    artifacts_dir_url=ARTIFACTS_DIR_URL_TEMPLATE,
     exported_model_types=[
         def_types.ModelArtifactType.STABLEHLO_MLIR,
         def_types.ModelArtifactType.XLA_HLO_DUMP,
@@ -56,7 +56,7 @@ BERT_LARGE_FP16_PT_384XI32_BATCH_TEMPLATE = utils.ModelTemplate(
         "import_on_gpu": True,
         "import_with_fx": True,
     },
-    artifacts_url=ARTIFACTS_URL_TEMPLATE,
+    artifacts_dir_url=ARTIFACTS_DIR_URL_TEMPLATE,
     exported_model_types=[
         def_types.ModelArtifactType.STABLEHLO_MLIR,
         def_types.ModelArtifactType.XLA_HLO_DUMP,
@@ -92,7 +92,7 @@ RESNET50_FP32_PT_3X224X224XF32_BATCH_TEMPLATE = utils.ModelTemplate(
         "import_on_gpu": False,
         "import_with_fx": True,
     },
-    artifacts_url=ARTIFACTS_URL_TEMPLATE,
+    artifacts_dir_url=ARTIFACTS_DIR_URL_TEMPLATE,
     exported_model_types=[
         def_types.ModelArtifactType.STABLEHLO_MLIR,
         def_types.ModelArtifactType.XLA_HLO_DUMP,
@@ -109,7 +109,7 @@ RESNET50_FP16_PT_3X224X224XF16_BATCH_TEMPLATE = utils.ModelTemplate(
         "import_on_gpu": True,
         "import_with_fx": False,
     },
-    artifacts_url=ARTIFACTS_URL_TEMPLATE,
+    artifacts_dir_url=ARTIFACTS_DIR_URL_TEMPLATE,
     exported_model_types=[
         def_types.ModelArtifactType.STABLEHLO_MLIR,
         def_types.ModelArtifactType.XLA_HLO_DUMP,

--- a/common_benchmark_suite/openxla/benchmark/comparative_suite/tf/benchmark_definitions.py
+++ b/common_benchmark_suite/openxla/benchmark/comparative_suite/tf/benchmark_definitions.py
@@ -27,10 +27,10 @@ BERT_LARGE_FP32_TF_384XI32_CASES = utils.build_batch_benchmark_cases(
     batch_sizes=[1, 16, 24, 32, 48, 64, 512, 1024, 1280],
 )
 
-RESNET50_FP32_TF_3X224X224XF32_CASES = utils.build_batch_benchmark_cases(
-    batch_models=model_definitions.RESNET50_FP32_TF_3X224X224XF32_BATCHES,
+RESNET50_FP32_TF_224X224X3XF32_CASES = utils.build_batch_benchmark_cases(
+    batch_models=model_definitions.RESNET50_FP32_TF_224X224X3XF32_BATCHES,
     batch_inputs=test_data_definitions.
-    INPUT_DATA_RESNET50_FP32_TF_3X224X224XF32_BATCHES,
+    INPUT_DATA_RESNET50_FP32_TF_224X224X3XF32_BATCHES,
     batch_expected_outputs=test_data_definitions.
     OUTPUT_DATA_RESNET50_FP32_TF_2048X7X7XF32_BATCHES,
     batch_sizes=[1, 8, 64, 128, 256, 2048],
@@ -40,5 +40,5 @@ ALL_BENCHMARKS = list(
     itertools.chain(
         T5_LARGE_FP32_TF_512XI32_CASES.values(),
         BERT_LARGE_FP32_TF_384XI32_CASES.values(),
-        RESNET50_FP32_TF_3X224X224XF32_CASES.values(),
+        RESNET50_FP32_TF_224X224X3XF32_CASES.values(),
     ))

--- a/common_benchmark_suite/openxla/benchmark/comparative_suite/tf/model_definitions.py
+++ b/common_benchmark_suite/openxla/benchmark/comparative_suite/tf/model_definitions.py
@@ -11,6 +11,7 @@ from openxla.benchmark import def_types
 from openxla.benchmark.comparative_suite import utils
 
 PARENT_GCS_DIR = "https://storage.googleapis.com/iree-model-artifacts/tensorflow/tf_models_2.13.0rc2_1688540251/"
+ARTIFACTS_URL_TEMPLATE = string.Template(PARENT_GCS_DIR + "${name}")
 
 # T5-Large models.
 # Model implementation from https://huggingface.co/docs/transformers/model_doc/t5#transformers.TFT5Model
@@ -31,31 +32,12 @@ T5_LARGE_FP32_TF_512XI32_BATCH_TEMPLATE = utils.ModelTemplate(
         "data_type": "fp32",
         "model_name": "t5-large",
     },
-    artifacts={
-        def_types.ModelArtifactType.STABLEHLO_MLIR:
-            utils.ModelArtifactTemplate(
-                artifact_type=def_types.ModelArtifactType.STABLEHLO_MLIR,
-                source_url=string.Template(
-                    PARENT_GCS_DIR +
-                    "T5_LARGE_FP32_TF_512XI32_BATCH${batch_size}/stablehlo.mlirbc"
-                ),
-            ),
-        def_types.ModelArtifactType.XLA_HLO_DUMP:
-            utils.ModelArtifactTemplate(
-                artifact_type=def_types.ModelArtifactType.XLA_HLO_DUMP,
-                source_url=string.Template(
-                    PARENT_GCS_DIR +
-                    "T5_LARGE_FP32_TF_512XI32_BATCH${batch_size}/xla_hlo_before_optimizations.txt"
-                ),
-            ),
-        def_types.ModelArtifactType.TF_SAVEDMODEL_V2:
-            utils.ModelArtifactTemplate(
-                artifact_type=def_types.ModelArtifactType.TF_SAVEDMODEL_V2,
-                source_url=string.Template(
-                    PARENT_GCS_DIR +
-                    "T5_LARGE_FP32_TF_512XI32_BATCH${batch_size}/tf-model.tgz"),
-            ),
-    },
+    artifacts_url=ARTIFACTS_URL_TEMPLATE,
+    exported_model_types=[
+        def_types.ModelArtifactType.STABLEHLO_MLIR,
+        def_types.ModelArtifactType.XLA_HLO_DUMP,
+        def_types.ModelArtifactType.TF_SAVEDMODEL_V2,
+    ],
 )
 T5_LARGE_FP32_TF_512XI32_BATCHES = utils.build_batch_models(
     template=T5_LARGE_FP32_TF_512XI32_BATCH_TEMPLATE,
@@ -82,32 +64,13 @@ BERT_LARGE_FP32_TF_384XI32_BATCH_TEMPLATE = utils.ModelTemplate(
         "seq_len": 384,
         "model_name": "bert-large-uncased",
     },
-    artifacts={
-        def_types.ModelArtifactType.STABLEHLO_MLIR:
-            utils.ModelArtifactTemplate(
-                artifact_type=def_types.ModelArtifactType.STABLEHLO_MLIR,
-                source_url=string.Template(
-                    PARENT_GCS_DIR +
-                    "BERT_LARGE_FP32_TF_384XI32_BATCH${batch_size}/stablehlo.mlirbc"
-                ),
-            ),
-        def_types.ModelArtifactType.XLA_HLO_DUMP:
-            utils.ModelArtifactTemplate(
-                artifact_type=def_types.ModelArtifactType.XLA_HLO_DUMP,
-                source_url=string.Template(
-                    PARENT_GCS_DIR +
-                    "BERT_LARGE_FP32_TF_384XI32_BATCH${batch_size}/xla_hlo_before_optimizations.txt"
-                ),
-            ),
-        def_types.ModelArtifactType.TF_SAVEDMODEL_V2:
-            utils.ModelArtifactTemplate(
-                artifact_type=def_types.ModelArtifactType.TF_SAVEDMODEL_V2,
-                source_url=string.Template(
-                    PARENT_GCS_DIR +
-                    "BERT_LARGE_FP32_TF_384XI32_BATCH${batch_size}/tf-model.tgz"
-                ),
-            ),
-    })
+    artifacts_url=ARTIFACTS_URL_TEMPLATE,
+    exported_model_types=[
+        def_types.ModelArtifactType.STABLEHLO_MLIR,
+        def_types.ModelArtifactType.XLA_HLO_DUMP,
+        def_types.ModelArtifactType.TF_SAVEDMODEL_V2,
+    ],
+)
 BERT_LARGE_FP32_TF_384XI32_BATCHES = utils.build_batch_models(
     template=BERT_LARGE_FP32_TF_384XI32_BATCH_TEMPLATE,
     batch_sizes=[1, 16, 24, 32, 48, 64, 512, 1024, 1280])
@@ -132,32 +95,13 @@ RESNET50_FP32_TF_3X224X224XF32_BATCH_TEMPLATE = utils.ModelTemplate(
         "data_type": "fp32",
         "model_name": "microsoft/resnet-50",
     },
-    artifacts={
-        def_types.ModelArtifactType.STABLEHLO_MLIR:
-            utils.ModelArtifactTemplate(
-                artifact_type=def_types.ModelArtifactType.STABLEHLO_MLIR,
-                source_url=string.Template(
-                    PARENT_GCS_DIR +
-                    "RESNET50_FP32_TF_224X224X3XF32_BATCH${batch_size}/stablehlo.mlirbc"
-                ),
-            ),
-        def_types.ModelArtifactType.XLA_HLO_DUMP:
-            utils.ModelArtifactTemplate(
-                artifact_type=def_types.ModelArtifactType.XLA_HLO_DUMP,
-                source_url=string.Template(
-                    PARENT_GCS_DIR +
-                    "RESNET50_FP32_TF_224X224X3XF32_BATCH${batch_size}/xla_hlo_before_optimizations.txt"
-                ),
-            ),
-        def_types.ModelArtifactType.TF_SAVEDMODEL_V2:
-            utils.ModelArtifactTemplate(
-                artifact_type=def_types.ModelArtifactType.TF_SAVEDMODEL_V2,
-                source_url=string.Template(
-                    PARENT_GCS_DIR +
-                    "RESNET50_FP32_TF_224X224X3XF32_BATCH${batch_size}/tf-model.tgz"
-                ),
-            ),
-    })
+    artifacts_url=ARTIFACTS_URL_TEMPLATE,
+    exported_model_types=[
+        def_types.ModelArtifactType.STABLEHLO_MLIR,
+        def_types.ModelArtifactType.XLA_HLO_DUMP,
+        def_types.ModelArtifactType.TF_SAVEDMODEL_V2,
+    ],
+)
 RESNET50_FP32_TF_3X224X224XF32_BATCHES = utils.build_batch_models(
     template=RESNET50_FP32_TF_3X224X224XF32_BATCH_TEMPLATE,
     batch_sizes=[1, 8, 64, 128, 256, 2048])

--- a/common_benchmark_suite/openxla/benchmark/comparative_suite/tf/model_definitions.py
+++ b/common_benchmark_suite/openxla/benchmark/comparative_suite/tf/model_definitions.py
@@ -11,7 +11,7 @@ from openxla.benchmark import def_types
 from openxla.benchmark.comparative_suite import utils
 
 PARENT_GCS_DIR = "https://storage.googleapis.com/iree-model-artifacts/tensorflow/tf_models_2.13.0rc2_1688540251/"
-ARTIFACTS_URL_TEMPLATE = string.Template(PARENT_GCS_DIR + "${name}")
+ARTIFACTS_DIR_URL_TEMPLATE = string.Template(PARENT_GCS_DIR + "${name}")
 
 # T5-Large models.
 # Model implementation from https://huggingface.co/docs/transformers/model_doc/t5#transformers.TFT5Model
@@ -32,7 +32,7 @@ T5_LARGE_FP32_TF_512XI32_BATCH_TEMPLATE = utils.ModelTemplate(
         "data_type": "fp32",
         "model_name": "t5-large",
     },
-    artifacts_url=ARTIFACTS_URL_TEMPLATE,
+    artifacts_dir_url=ARTIFACTS_DIR_URL_TEMPLATE,
     exported_model_types=[
         def_types.ModelArtifactType.STABLEHLO_MLIR,
         def_types.ModelArtifactType.XLA_HLO_DUMP,
@@ -64,7 +64,7 @@ BERT_LARGE_FP32_TF_384XI32_BATCH_TEMPLATE = utils.ModelTemplate(
         "seq_len": 384,
         "model_name": "bert-large-uncased",
     },
-    artifacts_url=ARTIFACTS_URL_TEMPLATE,
+    artifacts_dir_url=ARTIFACTS_DIR_URL_TEMPLATE,
     exported_model_types=[
         def_types.ModelArtifactType.STABLEHLO_MLIR,
         def_types.ModelArtifactType.XLA_HLO_DUMP,
@@ -95,7 +95,7 @@ RESNET50_FP32_TF_224X224X3XF32_BATCH_TEMPLATE = utils.ModelTemplate(
         "data_type": "fp32",
         "model_name": "microsoft/resnet-50",
     },
-    artifacts_url=ARTIFACTS_URL_TEMPLATE,
+    artifacts_dir_url=ARTIFACTS_DIR_URL_TEMPLATE,
     exported_model_types=[
         def_types.ModelArtifactType.STABLEHLO_MLIR,
         def_types.ModelArtifactType.XLA_HLO_DUMP,

--- a/common_benchmark_suite/openxla/benchmark/comparative_suite/tf/model_definitions.py
+++ b/common_benchmark_suite/openxla/benchmark/comparative_suite/tf/model_definitions.py
@@ -86,8 +86,8 @@ RESNET_TF_IMPL = def_types.ModelImplementation(
     source_info=
     "https://huggingface.co/docs/transformers/model_doc/resnet#transformers.TFResNetModel",
 )
-RESNET50_FP32_TF_3X224X224XF32_BATCH_TEMPLATE = utils.ModelTemplate(
-    name=utils.BATCH_NAME("RESNET50_FP32_TF_3X224X224XF32"),
+RESNET50_FP32_TF_224X224X3XF32_BATCH_TEMPLATE = utils.ModelTemplate(
+    name=utils.BATCH_NAME("RESNET50_FP32_TF_224X224X3XF32"),
     tags=[utils.BATCH_TAG, "fp32"],
     model_impl=RESNET_TF_IMPL,
     model_parameters={
@@ -102,13 +102,13 @@ RESNET50_FP32_TF_3X224X224XF32_BATCH_TEMPLATE = utils.ModelTemplate(
         def_types.ModelArtifactType.TF_SAVEDMODEL_V2,
     ],
 )
-RESNET50_FP32_TF_3X224X224XF32_BATCHES = utils.build_batch_models(
-    template=RESNET50_FP32_TF_3X224X224XF32_BATCH_TEMPLATE,
+RESNET50_FP32_TF_224X224X3XF32_BATCHES = utils.build_batch_models(
+    template=RESNET50_FP32_TF_224X224X3XF32_BATCH_TEMPLATE,
     batch_sizes=[1, 8, 64, 128, 256, 2048])
 
 ALL_MODELS = list(
     itertools.chain(
         T5_LARGE_FP32_TF_512XI32_BATCHES.values(),
         BERT_LARGE_FP32_TF_384XI32_BATCHES.values(),
-        RESNET50_FP32_TF_3X224X224XF32_BATCHES.values(),
+        RESNET50_FP32_TF_224X224X3XF32_BATCHES.values(),
     ))

--- a/common_benchmark_suite/openxla/benchmark/comparative_suite/tf/test_data_definitions.py
+++ b/common_benchmark_suite/openxla/benchmark/comparative_suite/tf/test_data_definitions.py
@@ -126,8 +126,8 @@ OUTPUT_DATA_BERT_LARGE_FP32_TF_384X1024XF32_BATCHES = utils.build_batch_model_te
     batch_sizes=[1, 16, 24, 32, 48, 64, 512, 1024, 1280])
 
 # ResNet50 inputs.
-INPUT_DATA_RESNET50_FP32_TF_3X224X224XF32_BATCH_TEMPLATE = utils.ModelTestDataTemplate(
-    name=utils.BATCH_NAME("INPUT_DATA_RESNET50_FP32_TF_3X224X224XF32"),
+INPUT_DATA_RESNET50_FP32_TF_224X224X3XF32_BATCH_TEMPLATE = utils.ModelTestDataTemplate(
+    name=utils.BATCH_NAME("INPUT_DATA_RESNET50_FP32_TF_224X224X3XF32"),
     tags=["input-data", "imagenet", utils.BATCH_TAG],
     source_info=
     "Original image: https://storage.googleapis.com/iree-model-artifacts/ILSVRC2012_val_00000023.JPEG",
@@ -146,8 +146,8 @@ INPUT_DATA_RESNET50_FP32_TF_3X224X224XF32_BATCH_TEMPLATE = utils.ModelTestDataTe
                     "RESNET50_FP32_TF_224X224X3XF32_BATCH${batch_size}/inputs_npy.tgz"
                 ))
     })
-INPUT_DATA_RESNET50_FP32_TF_3X224X224XF32_BATCHES = utils.build_batch_model_test_data(
-    template=INPUT_DATA_RESNET50_FP32_TF_3X224X224XF32_BATCH_TEMPLATE,
+INPUT_DATA_RESNET50_FP32_TF_224X224X3XF32_BATCHES = utils.build_batch_model_test_data(
+    template=INPUT_DATA_RESNET50_FP32_TF_224X224X3XF32_BATCH_TEMPLATE,
     batch_sizes=[1, 8, 64, 128, 256, 2048])
 
 # ResNet50 outputs.

--- a/common_benchmark_suite/openxla/benchmark/comparative_suite/utils.py
+++ b/common_benchmark_suite/openxla/benchmark/comparative_suite/utils.py
@@ -8,7 +8,7 @@
 import string
 import dataclasses
 from dataclasses import dataclass
-from typing import Any, Callable, Dict, List, Union, Sequence, Tuple
+from typing import Any, Callable, Dict, List, Optional, Sequence, Union
 
 from openxla.benchmark import def_types
 
@@ -36,7 +36,7 @@ class ModelTemplate:
   tags: List[Union[str, string.Template]]
   model_impl: def_types.ModelImplementation
   model_parameters: Dict[str, Any]
-  artifacts_dir_url: string.Template
+  artifacts_dir_url: Optional[string.Template] = None
   exported_model_types: List[def_types.ModelArtifactType] = dataclasses.field(
       default_factory=list)
 

--- a/common_benchmark_suite/openxla/benchmark/comparative_suite/utils.py
+++ b/common_benchmark_suite/openxla/benchmark/comparative_suite/utils.py
@@ -36,7 +36,7 @@ class ModelTemplate:
   tags: List[Union[str, string.Template]]
   model_impl: def_types.ModelImplementation
   model_parameters: Dict[str, Any]
-  artifacts_url: string.Template
+  artifacts_dir_url: string.Template
   exported_model_types: List[def_types.ModelArtifactType] = dataclasses.field(
       default_factory=list)
 
@@ -93,7 +93,7 @@ def build_batch_models(
         model_impl=template.model_impl,
         model_parameters=substitute(template.model_parameters),
         exported_model_types=template.exported_model_types,
-        artifacts_url=substitute(template.artifacts_url),
+        artifacts_dir_url=substitute(template.artifacts_dir_url),
     )
     batch_models[batch_size] = model
 

--- a/common_benchmark_suite/openxla/benchmark/comparative_suite/utils_test.py
+++ b/common_benchmark_suite/openxla/benchmark/comparative_suite/utils_test.py
@@ -28,12 +28,8 @@ class UtilsTest(unittest.TestCase):
             "batch_size": utils.BATCH_SIZE_PARAM,
             "data_type": "fp32",
         },
-        artifacts={
-            def_types.ModelArtifactType.STABLEHLO_MLIR:
-                utils.ModelArtifactTemplate(
-                    artifact_type=def_types.ModelArtifactType.STABLEHLO_MLIR,
-                    source_url=string.Template("batch_${batch_size}/x.mlirbc"))
-        },
+        artifacts_url=string.Template("test/${name}/batch_${batch_size}"),
+        exported_model_types=[def_types.ModelArtifactType.STABLEHLO_MLIR],
     )
 
     models = utils.build_batch_models(template=template, batch_sizes=[1, 2])
@@ -49,13 +45,10 @@ class UtilsTest(unittest.TestCase):
                         "batch_size": 1,
                         "data_type": "fp32",
                     },
-                    artifacts={
-                        def_types.ModelArtifactType.STABLEHLO_MLIR:
-                            def_types.ModelArtifact(
-                                artifact_type=def_types.ModelArtifactType.
-                                STABLEHLO_MLIR,
-                                source_url="batch_1/x.mlirbc")
-                    },
+                    artifacts_url="test/TEST_MODEL_BATCH1/batch_1",
+                    exported_model_types=[
+                        def_types.ModelArtifactType.STABLEHLO_MLIR
+                    ],
                 ),
             2:
                 def_types.Model(
@@ -66,13 +59,10 @@ class UtilsTest(unittest.TestCase):
                         "batch_size": 2,
                         "data_type": "fp32",
                     },
-                    artifacts={
-                        def_types.ModelArtifactType.STABLEHLO_MLIR:
-                            def_types.ModelArtifact(
-                                artifact_type=def_types.ModelArtifactType.
-                                STABLEHLO_MLIR,
-                                source_url="batch_2/x.mlirbc")
-                    },
+                    artifacts_url="test/TEST_MODEL_BATCH2/batch_2",
+                    exported_model_types=[
+                        def_types.ModelArtifactType.STABLEHLO_MLIR
+                    ],
                 ),
         })
 

--- a/common_benchmark_suite/openxla/benchmark/comparative_suite/utils_test.py
+++ b/common_benchmark_suite/openxla/benchmark/comparative_suite/utils_test.py
@@ -66,6 +66,53 @@ class UtilsTest(unittest.TestCase):
                 ),
         })
 
+  def test_build_batch_models_with_defaults(self):
+    dummy_impl = def_types.ModelImplementation(
+        name="TEST",
+        tags=["fp32"],
+        framework_type=def_types.ModelFrameworkType.JAX,
+        module_path=f"test.model",
+        source_info="")
+    template = utils.ModelTemplate(
+        name=utils.BATCH_NAME("TEST_MODEL"),
+        tags=[utils.BATCH_TAG, "test"],
+        model_impl=dummy_impl,
+        model_parameters={
+            "batch_size": utils.BATCH_SIZE_PARAM,
+            "data_type": "fp32",
+        },
+    )
+
+    models = utils.build_batch_models(template=template, batch_sizes=[1, 2])
+
+    self.assertEqual(
+        models, {
+            1:
+                def_types.Model(
+                    name="TEST_MODEL_BATCH1",
+                    tags=["batch-1", "test"],
+                    model_impl=dummy_impl,
+                    model_parameters={
+                        "batch_size": 1,
+                        "data_type": "fp32",
+                    },
+                    artifacts_dir_url=None,
+                    exported_model_types=[],
+                ),
+            2:
+                def_types.Model(
+                    name="TEST_MODEL_BATCH2",
+                    tags=["batch-2", "test"],
+                    model_impl=dummy_impl,
+                    model_parameters={
+                        "batch_size": 2,
+                        "data_type": "fp32",
+                    },
+                    artifacts_dir_url=None,
+                    exported_model_types=[],
+                ),
+        })
+
 
 if __name__ == "__main__":
   unittest.main()

--- a/common_benchmark_suite/openxla/benchmark/comparative_suite/utils_test.py
+++ b/common_benchmark_suite/openxla/benchmark/comparative_suite/utils_test.py
@@ -28,7 +28,7 @@ class UtilsTest(unittest.TestCase):
             "batch_size": utils.BATCH_SIZE_PARAM,
             "data_type": "fp32",
         },
-        artifacts_url=string.Template("test/${name}/batch_${batch_size}"),
+        artifacts_dir_url=string.Template("test/${name}/batch_${batch_size}"),
         exported_model_types=[def_types.ModelArtifactType.STABLEHLO_MLIR],
     )
 
@@ -45,7 +45,7 @@ class UtilsTest(unittest.TestCase):
                         "batch_size": 1,
                         "data_type": "fp32",
                     },
-                    artifacts_url="test/TEST_MODEL_BATCH1/batch_1",
+                    artifacts_dir_url="test/TEST_MODEL_BATCH1/batch_1",
                     exported_model_types=[
                         def_types.ModelArtifactType.STABLEHLO_MLIR
                     ],
@@ -59,7 +59,7 @@ class UtilsTest(unittest.TestCase):
                         "batch_size": 2,
                         "data_type": "fp32",
                     },
-                    artifacts_url="test/TEST_MODEL_BATCH2/batch_2",
+                    artifacts_dir_url="test/TEST_MODEL_BATCH2/batch_2",
                     exported_model_types=[
                         def_types.ModelArtifactType.STABLEHLO_MLIR
                     ],

--- a/common_benchmark_suite/openxla/benchmark/def_types.py
+++ b/common_benchmark_suite/openxla/benchmark/def_types.py
@@ -8,7 +8,7 @@
 import dataclasses
 from dataclasses import dataclass
 from enum import Enum
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
 
 
 class ModelFrameworkType(Enum):
@@ -58,7 +58,7 @@ class Model:
   # Parameters to initialize the model, e.g., input batch size, sequence length.
   model_parameters: Dict[str, Any]
   # URLs to download exported models and generated test data.
-  artifacts_dir_url: str
+  artifacts_dir_url: Optional[str] = None
   # Types of exported models.
   exported_model_types: List[ModelArtifactType] = dataclasses.field(
       default_factory=list)

--- a/common_benchmark_suite/openxla/benchmark/def_types.py
+++ b/common_benchmark_suite/openxla/benchmark/def_types.py
@@ -58,7 +58,7 @@ class Model:
   # Parameters to initialize the model, e.g., input batch size, sequence length.
   model_parameters: Dict[str, Any]
   # URLs to download exported models and generated test data.
-  artifacts_url: str
+  artifacts_dir_url: str
   # Types of exported models.
   exported_model_types: List[ModelArtifactType] = dataclasses.field(
       default_factory=list)

--- a/common_benchmark_suite/openxla/benchmark/def_types.py
+++ b/common_benchmark_suite/openxla/benchmark/def_types.py
@@ -5,6 +5,7 @@
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 """Types of the benchmark definitions."""
 
+import dataclasses
 from dataclasses import dataclass
 from enum import Enum
 from typing import Any, Dict, List
@@ -46,13 +47,6 @@ class ModelArtifactType(Enum):
 
 
 @dataclass(frozen=True)
-class ModelArtifact:
-  """A specific derived model."""
-  artifact_type: ModelArtifactType
-  source_url: str
-
-
-@dataclass(frozen=True)
 class Model:
   """A model with concrete parameters to initialize."""
   # Friendly unique name.
@@ -63,8 +57,11 @@ class Model:
   model_impl: ModelImplementation
   # Parameters to initialize the model, e.g., input batch size, sequence length.
   model_parameters: Dict[str, Any]
-  # URLs to download the derived models of the initialized model.
-  artifacts: Dict[ModelArtifactType, ModelArtifact]
+  # URLs to download exported models and generated test data.
+  artifacts_url: str
+  # Types of exported models.
+  exported_model_types: List[ModelArtifactType] = dataclasses.field(
+      default_factory=list)
 
   def __str__(self):
     return self.name

--- a/comparative_benchmark/xla_hlo/run_benchmarks.py
+++ b/comparative_benchmark/xla_hlo/run_benchmarks.py
@@ -269,10 +269,13 @@ def _download_artifacts(benchmarks: Sequence[def_types.BenchmarkCase],
 
   download_list = []
   for benchmark in benchmarks:
-    model_artifact = benchmark.model.artifacts[
-        def_types.ModelArtifactType.XLA_HLO_DUMP]
-    model_path = root_dir / benchmark.model.name / HLO_FILENAME
-    download_list.append((model_artifact.source_url, model_path))
+    model = benchmark.model
+    if (def_types.ModelArtifactType.XLA_HLO_DUMP
+        not in model.exported_model_types):
+      raise ValueError(f"XLA HLO dump isn't provided by '{model.name}'.")
+    model_url = model.artifacts_url + "/" + HLO_FILENAME
+    model_path = root_dir / model.name / HLO_FILENAME
+    download_list.append((model_url, model_path))
 
   utils.download_files(download_list, verbose=verbose)
 

--- a/comparative_benchmark/xla_hlo/run_benchmarks.py
+++ b/comparative_benchmark/xla_hlo/run_benchmarks.py
@@ -273,7 +273,7 @@ def _download_artifacts(benchmarks: Sequence[def_types.BenchmarkCase],
     if (def_types.ModelArtifactType.XLA_HLO_DUMP
         not in model.exported_model_types):
       raise ValueError(f"XLA HLO dump isn't provided by '{model.name}'.")
-    model_url = model.artifacts_url + "/" + HLO_FILENAME
+    model_url = model.artifacts_dir_url + "/" + HLO_FILENAME
     model_path = root_dir / model.name / HLO_FILENAME
     download_list.append((model_url, model_path))
 

--- a/comparative_benchmark/xla_hlo/run_benchmarks.py
+++ b/comparative_benchmark/xla_hlo/run_benchmarks.py
@@ -270,7 +270,8 @@ def _download_artifacts(benchmarks: Sequence[def_types.BenchmarkCase],
   download_list = []
   for benchmark in benchmarks:
     model = benchmark.model
-    if (def_types.ModelArtifactType.XLA_HLO_DUMP
+    if (model.artifacts_dir_url is None or
+        def_types.ModelArtifactType.XLA_HLO_DUMP
         not in model.exported_model_types):
       raise ValueError(f"XLA HLO dump isn't provided by '{model.name}'.")
     model_url = model.artifacts_dir_url + "/" + HLO_FILENAME


### PR DESCRIPTION
Instead of giving multiple URLs of the files under the model GCS directory, we can provide a single root GCS URL and all files can be downloaded under it.

This is also the first step to simplify test data definitions (#85). With this change, the generated test data can also be downloaded from the same root URL.