### PR TITLE
Make framework benchmarks locally runnable without downloading artifacts

### DIFF
--- a/.github/workflows/run_comparative_benchmark.yml
+++ b/.github/workflows/run_comparative_benchmark.yml
@@ -13,6 +13,7 @@ on:
     # Scheduled to run at 09:00 UTC and 21:00 UTC.
     - cron: '0 09,21 * * *'
   workflow_dispatch:
+  pull_request:
 
 concurrency:
   # A PR number if a pull request and otherwise the commit hash. This cancels
@@ -100,81 +101,81 @@ jobs:
           gcloud storage cp "${XLA_TOOLS_DIR_ARCHIVE}" "${XLA_TOOLS_DIR_GCS_ARTIFACT}"
           echo "xla-tools-dir-gcs-artifact=${XLA_TOOLS_DIR_GCS_ARTIFACT}" >> "${GITHUB_OUTPUT}"
 
-  benchmark_on_a2-highgpu-1g:
-    needs: [setup, build_xla_tools]
-    runs-on:
-      - self-hosted  # must come first
-      - runner-group=${{ needs.setup.outputs.runner-group }}
-      - environment=prod
-      - machine-type=a2-highgpu-1g
-    env:
-      BENCHMARK_GCS_DIR: ${{ needs.setup.outputs.benchmark-gcs-dir }}
-      RESULTS_DIR: results-dir
-      TARGET_DEVICE: a2-highgpu-1g
-      XLA_TOOLS_DIR: ${{ needs.build_xla_tools.outputs.xla-tools-dir }}
-      XLA_TOOLS_DIR_ARCHIVE: ${{ needs.build_xla_tools.outputs.xla-tools-dir-archive }}
-      XLA_TOOLS_DIR_GCS_ARTIFACT: ${{ needs.build_xla_tools.outputs.xla-tools-dir-gcs-artifact }}
-    steps:
-      - name: "Checking out PR repository"
-        uses: actions/checkout@e2f20e631ae6d7dd3b768f56a5d2af784dd54791  # v2.5.0
-      - name: "Setup"
-        id: setup
-        run: |
-          echo "results-gcs-dir=${BENCHMARK_GCS_DIR}/${TARGET_DEVICE}-results" >> "${GITHUB_OUTPUT}"
-          mkdir "${RESULTS_DIR}"
-      - name: "Downloading and unpacking XLA tools"
-        run: |
-          gcloud storage cp "${XLA_TOOLS_DIR_GCS_ARTIFACT}" "${XLA_TOOLS_DIR_ARCHIVE}"
-          tar -xvf "${XLA_TOOLS_DIR_ARCHIVE}"
-      - name: "Benchmarking XLA-HLO:GPU"
-        env:
-          XLA_HLO_RESULTS_JSON: xla-hlo.json
-          RESULTS_GCS_DIR: ${{ steps.setup.outputs.results-gcs-dir }}
-        run: |
-          RESULTS_PATH="${RESULTS_DIR}/${XLA_HLO_RESULTS_JSON}"
-          docker run --gpus all --mount="type=bind,src="${PWD}",target=/work" --workdir="/work" \
-            --env "OOBI_XLA_TOOLS_DIR=${XLA_TOOLS_DIR}" \
-            "gcr.io/iree-oss/openxla-benchmark/cuda11.8-cudnn8.9@sha256:c39107c4160e749b7c4bac18862c6c1b6d56e1aa60644a4fe323e315ffba0a0b" \
-            ./comparative_benchmark/xla_hlo/benchmark_all.sh \
-              "${TARGET_DEVICE}"\
-              "${RESULTS_PATH}"
-          gcloud storage cp "${RESULTS_PATH}" "${RESULTS_GCS_DIR}/"
-      - name: "Benchmarking JAX-XLA:GPU"
-        env:
-          JAX_XLA_RESULTS_JSON: jax-xla.json
-          RESULTS_GCS_DIR: ${{ steps.setup.outputs.results-gcs-dir }}
-        run: |
-          RESULTS_PATH="${RESULTS_DIR}/${JAX_XLA_RESULTS_JSON}"
-          docker run --gpus all --mount="type=bind,src="${PWD}",target=/work" --workdir="/work" \
-            "gcr.io/iree-oss/openxla-benchmark/cuda11.8-cudnn8.9@sha256:c39107c4160e749b7c4bac18862c6c1b6d56e1aa60644a4fe323e315ffba0a0b" \
-            ./comparative_benchmark/jax_xla/benchmark_all.sh \
-              "${TARGET_DEVICE}"\
-              "${RESULTS_PATH}"
-          gcloud storage cp "${RESULTS_PATH}" "${RESULTS_GCS_DIR}/"
-      - name: "Benchmarking TF-XLA:GPU"
-        env:
-          TF_XLA_RESULTS_JSON: tf-xla.json
-          RESULTS_GCS_DIR: ${{ steps.setup.outputs.results-gcs-dir }}
-        run: |
-          RESULTS_PATH="${RESULTS_DIR}/${TF_XLA_RESULTS_JSON}"
-          docker run --gpus all --mount="type=bind,src="${PWD}",target=/work" --workdir="/work" \
-            "gcr.io/iree-oss/openxla-benchmark/cuda11.8-cudnn8.9@sha256:c39107c4160e749b7c4bac18862c6c1b6d56e1aa60644a4fe323e315ffba0a0b" \
-            ./comparative_benchmark/tf_xla/benchmark_all.sh \
-              "${TARGET_DEVICE}"\
-              "${RESULTS_PATH}"
-          gcloud storage cp "${RESULTS_PATH}" "${RESULTS_GCS_DIR}/"
-      - name: "Benchmarking PT-Inductor:GPU"
-        env:
-          PT_INDUCTOR_RESULTS_JSON: pt-inductor.json
-          RESULTS_GCS_DIR: ${{ steps.setup.outputs.results-gcs-dir }}
-        run: |
-          RESULTS_PATH="${RESULTS_DIR}/${PT_INDUCTOR_RESULTS_JSON}"
-          docker run --gpus all --mount="type=bind,src="${PWD}",target=/work" --workdir="/work" \
-            "gcr.io/iree-oss/openxla-benchmark/cuda11.8-cudnn8.9@sha256:c39107c4160e749b7c4bac18862c6c1b6d56e1aa60644a4fe323e315ffba0a0b" \
-            ./comparative_benchmark/pt_inductor/benchmark_all.sh \
-              "${TARGET_DEVICE}"\
-              "${RESULTS_PATH}"
-          gcloud storage cp "${RESULTS_PATH}" "${RESULTS_GCS_DIR}/"
+  # benchmark_on_a2-highgpu-1g:
+  #   needs: [setup, build_xla_tools]
+  #   runs-on:
+  #     - self-hosted  # must come first
+  #     - runner-group=${{ needs.setup.outputs.runner-group }}
+  #     - environment=prod
+  #     - machine-type=a2-highgpu-1g
+  #   env:
+  #     BENCHMARK_GCS_DIR: ${{ needs.setup.outputs.benchmark-gcs-dir }}
+  #     RESULTS_DIR: results-dir
+  #     TARGET_DEVICE: a2-highgpu-1g
+  #     XLA_TOOLS_DIR: ${{ needs.build_xla_tools.outputs.xla-tools-dir }}
+  #     XLA_TOOLS_DIR_ARCHIVE: ${{ needs.build_xla_tools.outputs.xla-tools-dir-archive }}
+  #     XLA_TOOLS_DIR_GCS_ARTIFACT: ${{ needs.build_xla_tools.outputs.xla-tools-dir-gcs-artifact }}
+  #   steps:
+  #     - name: "Checking out PR repository"
+  #       uses: actions/checkout@e2f20e631ae6d7dd3b768f56a5d2af784dd54791  # v2.5.0
+  #     - name: "Setup"
+  #       id: setup
+  #       run: |
+  #         echo "results-gcs-dir=${BENCHMARK_GCS_DIR}/${TARGET_DEVICE}-results" >> "${GITHUB_OUTPUT}"
+  #         mkdir "${RESULTS_DIR}"
+  #     - name: "Downloading and unpacking XLA tools"
+  #       run: |
+  #         gcloud storage cp "${XLA_TOOLS_DIR_GCS_ARTIFACT}" "${XLA_TOOLS_DIR_ARCHIVE}"
+  #         tar -xvf "${XLA_TOOLS_DIR_ARCHIVE}"
+  #     - name: "Benchmarking XLA-HLO:GPU"
+  #       env:
+  #         XLA_HLO_RESULTS_JSON: xla-hlo.json
+  #         RESULTS_GCS_DIR: ${{ steps.setup.outputs.results-gcs-dir }}
+  #       run: |
+  #         RESULTS_PATH="${RESULTS_DIR}/${XLA_HLO_RESULTS_JSON}"
+  #         docker run --gpus all --mount="type=bind,src="${PWD}",target=/work" --workdir="/work" \
+  #           --env "OOBI_XLA_TOOLS_DIR=${XLA_TOOLS_DIR}" \
+  #           "gcr.io/iree-oss/openxla-benchmark/cuda11.8-cudnn8.9@sha256:c39107c4160e749b7c4bac18862c6c1b6d56e1aa60644a4fe323e315ffba0a0b" \
+  #           ./comparative_benchmark/xla_hlo/benchmark_all.sh \
+  #             "${TARGET_DEVICE}"\
+  #             "${RESULTS_PATH}"
+  #         gcloud storage cp "${RESULTS_PATH}" "${RESULTS_GCS_DIR}/"
+  #     - name: "Benchmarking JAX-XLA:GPU"
+  #       env:
+  #         JAX_XLA_RESULTS_JSON: jax-xla.json
+  #         RESULTS_GCS_DIR: ${{ steps.setup.outputs.results-gcs-dir }}
+  #       run: |
+  #         RESULTS_PATH="${RESULTS_DIR}/${JAX_XLA_RESULTS_JSON}"
+  #         docker run --gpus all --mount="type=bind,src="${PWD}",target=/work" --workdir="/work" \
+  #           "gcr.io/iree-oss/openxla-benchmark/cuda11.8-cudnn8.9@sha256:c39107c4160e749b7c4bac18862c6c1b6d56e1aa60644a4fe323e315ffba0a0b" \
+  #           ./comparative_benchmark/jax_xla/benchmark_all.sh \
+  #             "${TARGET_DEVICE}"\
+  #             "${RESULTS_PATH}"
+  #         gcloud storage cp "${RESULTS_PATH}" "${RESULTS_GCS_DIR}/"
+  #     - name: "Benchmarking TF-XLA:GPU"
+  #       env:
+  #         TF_XLA_RESULTS_JSON: tf-xla.json
+  #         RESULTS_GCS_DIR: ${{ steps.setup.outputs.results-gcs-dir }}
+  #       run: |
+  #         RESULTS_PATH="${RESULTS_DIR}/${TF_XLA_RESULTS_JSON}"
+  #         docker run --gpus all --mount="type=bind,src="${PWD}",target=/work" --workdir="/work" \
+  #           "gcr.io/iree-oss/openxla-benchmark/cuda11.8-cudnn8.9@sha256:c39107c4160e749b7c4bac18862c6c1b6d56e1aa60644a4fe323e315ffba0a0b" \
+  #           ./comparative_benchmark/tf_xla/benchmark_all.sh \
+  #             "${TARGET_DEVICE}"\
+  #             "${RESULTS_PATH}"
+  #         gcloud storage cp "${RESULTS_PATH}" "${RESULTS_GCS_DIR}/"
+  #     - name: "Benchmarking PT-Inductor:GPU"
+  #       env:
+  #         PT_INDUCTOR_RESULTS_JSON: pt-inductor.json
+  #         RESULTS_GCS_DIR: ${{ steps.setup.outputs.results-gcs-dir }}
+  #       run: |
+  #         RESULTS_PATH="${RESULTS_DIR}/${PT_INDUCTOR_RESULTS_JSON}"
+  #         docker run --gpus all --mount="type=bind,src="${PWD}",target=/work" --workdir="/work" \
+  #           "gcr.io/iree-oss/openxla-benchmark/cuda11.8-cudnn8.9@sha256:c39107c4160e749b7c4bac18862c6c1b6d56e1aa60644a4fe323e315ffba0a0b" \
+  #           ./comparative_benchmark/pt_inductor/benchmark_all.sh \
+  #             "${TARGET_DEVICE}"\
+  #             "${RESULTS_PATH}"
+  #         gcloud storage cp "${RESULTS_PATH}" "${RESULTS_GCS_DIR}/"
 
   benchmark_on_c2-standard-16:
     needs: [setup, build_xla_tools]

--- a/.github/workflows/run_comparative_benchmark.yml
+++ b/.github/workflows/run_comparative_benchmark.yml
@@ -13,7 +13,6 @@ on:
     # Scheduled to run at 09:00 UTC and 21:00 UTC.
     - cron: '0 09,21 * * *'
   workflow_dispatch:
-  pull_request:
 
 concurrency:
   # A PR number if a pull request and otherwise the commit hash. This cancels
@@ -101,81 +100,81 @@ jobs:
           gcloud storage cp "${XLA_TOOLS_DIR_ARCHIVE}" "${XLA_TOOLS_DIR_GCS_ARTIFACT}"
           echo "xla-tools-dir-gcs-artifact=${XLA_TOOLS_DIR_GCS_ARTIFACT}" >> "${GITHUB_OUTPUT}"
 
-  # benchmark_on_a2-highgpu-1g:
-  #   needs: [setup, build_xla_tools]
-  #   runs-on:
-  #     - self-hosted  # must come first
-  #     - runner-group=${{ needs.setup.outputs.runner-group }}
-  #     - environment=prod
-  #     - machine-type=a2-highgpu-1g
-  #   env:
-  #     BENCHMARK_GCS_DIR: ${{ needs.setup.outputs.benchmark-gcs-dir }}
-  #     RESULTS_DIR: results-dir
-  #     TARGET_DEVICE: a2-highgpu-1g
-  #     XLA_TOOLS_DIR: ${{ needs.build_xla_tools.outputs.xla-tools-dir }}
-  #     XLA_TOOLS_DIR_ARCHIVE: ${{ needs.build_xla_tools.outputs.xla-tools-dir-archive }}
-  #     XLA_TOOLS_DIR_GCS_ARTIFACT: ${{ needs.build_xla_tools.outputs.xla-tools-dir-gcs-artifact }}
-  #   steps:
-  #     - name: "Checking out PR repository"
-  #       uses: actions/checkout@e2f20e631ae6d7dd3b768f56a5d2af784dd54791  # v2.5.0
-  #     - name: "Setup"
-  #       id: setup
-  #       run: |
-  #         echo "results-gcs-dir=${BENCHMARK_GCS_DIR}/${TARGET_DEVICE}-results" >> "${GITHUB_OUTPUT}"
-  #         mkdir "${RESULTS_DIR}"
-  #     - name: "Downloading and unpacking XLA tools"
-  #       run: |
-  #         gcloud storage cp "${XLA_TOOLS_DIR_GCS_ARTIFACT}" "${XLA_TOOLS_DIR_ARCHIVE}"
-  #         tar -xvf "${XLA_TOOLS_DIR_ARCHIVE}"
-  #     - name: "Benchmarking XLA-HLO:GPU"
-  #       env:
-  #         XLA_HLO_RESULTS_JSON: xla-hlo.json
-  #         RESULTS_GCS_DIR: ${{ steps.setup.outputs.results-gcs-dir }}
-  #       run: |
-  #         RESULTS_PATH="${RESULTS_DIR}/${XLA_HLO_RESULTS_JSON}"
-  #         docker run --gpus all --mount="type=bind,src="${PWD}",target=/work" --workdir="/work" \
-  #           --env "OOBI_XLA_TOOLS_DIR=${XLA_TOOLS_DIR}" \
-  #           "gcr.io/iree-oss/openxla-benchmark/cuda11.8-cudnn8.9@sha256:c39107c4160e749b7c4bac18862c6c1b6d56e1aa60644a4fe323e315ffba0a0b" \
-  #           ./comparative_benchmark/xla_hlo/benchmark_all.sh \
-  #             "${TARGET_DEVICE}"\
-  #             "${RESULTS_PATH}"
-  #         gcloud storage cp "${RESULTS_PATH}" "${RESULTS_GCS_DIR}/"
-  #     - name: "Benchmarking JAX-XLA:GPU"
-  #       env:
-  #         JAX_XLA_RESULTS_JSON: jax-xla.json
-  #         RESULTS_GCS_DIR: ${{ steps.setup.outputs.results-gcs-dir }}
-  #       run: |
-  #         RESULTS_PATH="${RESULTS_DIR}/${JAX_XLA_RESULTS_JSON}"
-  #         docker run --gpus all --mount="type=bind,src="${PWD}",target=/work" --workdir="/work" \
-  #           "gcr.io/iree-oss/openxla-benchmark/cuda11.8-cudnn8.9@sha256:c39107c4160e749b7c4bac18862c6c1b6d56e1aa60644a4fe323e315ffba0a0b" \
-  #           ./comparative_benchmark/jax_xla/benchmark_all.sh \
-  #             "${TARGET_DEVICE}"\
-  #             "${RESULTS_PATH}"
-  #         gcloud storage cp "${RESULTS_PATH}" "${RESULTS_GCS_DIR}/"
-  #     - name: "Benchmarking TF-XLA:GPU"
-  #       env:
-  #         TF_XLA_RESULTS_JSON: tf-xla.json
-  #         RESULTS_GCS_DIR: ${{ steps.setup.outputs.results-gcs-dir }}
-  #       run: |
-  #         RESULTS_PATH="${RESULTS_DIR}/${TF_XLA_RESULTS_JSON}"
-  #         docker run --gpus all --mount="type=bind,src="${PWD}",target=/work" --workdir="/work" \
-  #           "gcr.io/iree-oss/openxla-benchmark/cuda11.8-cudnn8.9@sha256:c39107c4160e749b7c4bac18862c6c1b6d56e1aa60644a4fe323e315ffba0a0b" \
-  #           ./comparative_benchmark/tf_xla/benchmark_all.sh \
-  #             "${TARGET_DEVICE}"\
-  #             "${RESULTS_PATH}"
-  #         gcloud storage cp "${RESULTS_PATH}" "${RESULTS_GCS_DIR}/"
-  #     - name: "Benchmarking PT-Inductor:GPU"
-  #       env:
-  #         PT_INDUCTOR_RESULTS_JSON: pt-inductor.json
-  #         RESULTS_GCS_DIR: ${{ steps.setup.outputs.results-gcs-dir }}
-  #       run: |
-  #         RESULTS_PATH="${RESULTS_DIR}/${PT_INDUCTOR_RESULTS_JSON}"
-  #         docker run --gpus all --mount="type=bind,src="${PWD}",target=/work" --workdir="/work" \
-  #           "gcr.io/iree-oss/openxla-benchmark/cuda11.8-cudnn8.9@sha256:c39107c4160e749b7c4bac18862c6c1b6d56e1aa60644a4fe323e315ffba0a0b" \
-  #           ./comparative_benchmark/pt_inductor/benchmark_all.sh \
-  #             "${TARGET_DEVICE}"\
-  #             "${RESULTS_PATH}"
-  #         gcloud storage cp "${RESULTS_PATH}" "${RESULTS_GCS_DIR}/"
+  benchmark_on_a2-highgpu-1g:
+    needs: [setup, build_xla_tools]
+    runs-on:
+      - self-hosted  # must come first
+      - runner-group=${{ needs.setup.outputs.runner-group }}
+      - environment=prod
+      - machine-type=a2-highgpu-1g
+    env:
+      BENCHMARK_GCS_DIR: ${{ needs.setup.outputs.benchmark-gcs-dir }}
+      RESULTS_DIR: results-dir
+      TARGET_DEVICE: a2-highgpu-1g
+      XLA_TOOLS_DIR: ${{ needs.build_xla_tools.outputs.xla-tools-dir }}
+      XLA_TOOLS_DIR_ARCHIVE: ${{ needs.build_xla_tools.outputs.xla-tools-dir-archive }}
+      XLA_TOOLS_DIR_GCS_ARTIFACT: ${{ needs.build_xla_tools.outputs.xla-tools-dir-gcs-artifact }}
+    steps:
+      - name: "Checking out PR repository"
+        uses: actions/checkout@e2f20e631ae6d7dd3b768f56a5d2af784dd54791  # v2.5.0
+      - name: "Setup"
+        id: setup
+        run: |
+          echo "results-gcs-dir=${BENCHMARK_GCS_DIR}/${TARGET_DEVICE}-results" >> "${GITHUB_OUTPUT}"
+          mkdir "${RESULTS_DIR}"
+      - name: "Downloading and unpacking XLA tools"
+        run: |
+          gcloud storage cp "${XLA_TOOLS_DIR_GCS_ARTIFACT}" "${XLA_TOOLS_DIR_ARCHIVE}"
+          tar -xvf "${XLA_TOOLS_DIR_ARCHIVE}"
+      - name: "Benchmarking XLA-HLO:GPU"
+        env:
+          XLA_HLO_RESULTS_JSON: xla-hlo.json
+          RESULTS_GCS_DIR: ${{ steps.setup.outputs.results-gcs-dir }}
+        run: |
+          RESULTS_PATH="${RESULTS_DIR}/${XLA_HLO_RESULTS_JSON}"
+          docker run --gpus all --mount="type=bind,src="${PWD}",target=/work" --workdir="/work" \
+            --env "OOBI_XLA_TOOLS_DIR=${XLA_TOOLS_DIR}" \
+            "gcr.io/iree-oss/openxla-benchmark/cuda11.8-cudnn8.9@sha256:c39107c4160e749b7c4bac18862c6c1b6d56e1aa60644a4fe323e315ffba0a0b" \
+            ./comparative_benchmark/xla_hlo/benchmark_all.sh \
+              "${TARGET_DEVICE}"\
+              "${RESULTS_PATH}"
+          gcloud storage cp "${RESULTS_PATH}" "${RESULTS_GCS_DIR}/"
+      - name: "Benchmarking JAX-XLA:GPU"
+        env:
+          JAX_XLA_RESULTS_JSON: jax-xla.json
+          RESULTS_GCS_DIR: ${{ steps.setup.outputs.results-gcs-dir }}
+        run: |
+          RESULTS_PATH="${RESULTS_DIR}/${JAX_XLA_RESULTS_JSON}"
+          docker run --gpus all --mount="type=bind,src="${PWD}",target=/work" --workdir="/work" \
+            "gcr.io/iree-oss/openxla-benchmark/cuda11.8-cudnn8.9@sha256:c39107c4160e749b7c4bac18862c6c1b6d56e1aa60644a4fe323e315ffba0a0b" \
+            ./comparative_benchmark/jax_xla/benchmark_all.sh \
+              "${TARGET_DEVICE}"\
+              "${RESULTS_PATH}"
+          gcloud storage cp "${RESULTS_PATH}" "${RESULTS_GCS_DIR}/"
+      - name: "Benchmarking TF-XLA:GPU"
+        env:
+          TF_XLA_RESULTS_JSON: tf-xla.json
+          RESULTS_GCS_DIR: ${{ steps.setup.outputs.results-gcs-dir }}
+        run: |
+          RESULTS_PATH="${RESULTS_DIR}/${TF_XLA_RESULTS_JSON}"
+          docker run --gpus all --mount="type=bind,src="${PWD}",target=/work" --workdir="/work" \
+            "gcr.io/iree-oss/openxla-benchmark/cuda11.8-cudnn8.9@sha256:c39107c4160e749b7c4bac18862c6c1b6d56e1aa60644a4fe323e315ffba0a0b" \
+            ./comparative_benchmark/tf_xla/benchmark_all.sh \
+              "${TARGET_DEVICE}"\
+              "${RESULTS_PATH}"
+          gcloud storage cp "${RESULTS_PATH}" "${RESULTS_GCS_DIR}/"
+      - name: "Benchmarking PT-Inductor:GPU"
+        env:
+          PT_INDUCTOR_RESULTS_JSON: pt-inductor.json
+          RESULTS_GCS_DIR: ${{ steps.setup.outputs.results-gcs-dir }}
+        run: |
+          RESULTS_PATH="${RESULTS_DIR}/${PT_INDUCTOR_RESULTS_JSON}"
+          docker run --gpus all --mount="type=bind,src="${PWD}",target=/work" --workdir="/work" \
+            "gcr.io/iree-oss/openxla-benchmark/cuda11.8-cudnn8.9@sha256:c39107c4160e749b7c4bac18862c6c1b6d56e1aa60644a4fe323e315ffba0a0b" \
+            ./comparative_benchmark/pt_inductor/benchmark_all.sh \
+              "${TARGET_DEVICE}"\
+              "${RESULTS_PATH}"
+          gcloud storage cp "${RESULTS_PATH}" "${RESULTS_GCS_DIR}/"
 
   benchmark_on_c2-standard-16:
     needs: [setup, build_xla_tools]

--- a/common_benchmark_suite/openxla/benchmark/comparative_suite/jax/scripts/generate_model_artifacts.py
+++ b/common_benchmark_suite/openxla/benchmark/comparative_suite/jax/scripts/generate_model_artifacts.py
@@ -5,7 +5,6 @@
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 import argparse
-import importlib
 import jax
 import os
 import pathlib
@@ -14,14 +13,13 @@ import multiprocessing
 import shutil
 import subprocess
 import sys
-
-from typing import Any, Optional, Tuple, Union
+from typing import Any, Optional
 
 # Add openxla dir to the search path.
 sys.path.insert(0, str(pathlib.Path(__file__).parents[5]))
 from openxla.benchmark import def_types
 from openxla.benchmark.comparative_suite.jax import model_definitions
-from openxla.benchmark.models import model_interfaces, utils
+from openxla.benchmark.models import utils
 
 HLO_FILENAME_REGEX = r".*jit_forward.before_optimizations.txt"
 
@@ -57,9 +55,7 @@ def _generate_artifacts(model: def_types.Model, save_dir: pathlib.Path,
     os.environ[
         "XLA_FLAGS"] = f"--xla_dump_to={hlo_dir} --xla_dump_hlo_module_re=.*jit_forward.*"
 
-    model_module = importlib.import_module(model.model_impl.module_path)
-    model_obj: model_interfaces.InferenceModel = model_module.create_model(
-        **model.model_parameters)
+    model_obj = utils.create_model_obj(model)
 
     inputs = utils.generate_and_save_inputs(model_obj, model_dir)
     jit_inputs = jax.device_put(inputs)

--- a/common_benchmark_suite/openxla/benchmark/comparative_suite/pt/scripts/generate_model_artifacts.py
+++ b/common_benchmark_suite/openxla/benchmark/comparative_suite/pt/scripts/generate_model_artifacts.py
@@ -5,7 +5,6 @@
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 import argparse
-import importlib
 import pathlib
 import re
 import multiprocessing
@@ -20,7 +19,7 @@ from import_utils import import_torch_module_with_fx, import_torch_module
 sys.path.insert(0, str(pathlib.Path(__file__).parents[5]))
 from openxla.benchmark import def_types
 from openxla.benchmark.comparative_suite.pt import model_definitions
-from openxla.benchmark.models import model_interfaces, utils
+from openxla.benchmark.models import utils
 
 
 def _generate_artifacts(model: def_types.Model, save_dir: pathlib.Path):
@@ -31,9 +30,8 @@ def _generate_artifacts(model: def_types.Model, save_dir: pathlib.Path):
   try:
     # Remove all gradient info from models and tensors since these models are inference only.
     with torch.no_grad():
-      model_module = importlib.import_module(model.model_impl.module_path)
-      model_obj: model_interfaces.InferenceModel = model_module.create_model(
-          **model.model_parameters)
+      model_obj = utils.create_model_obj(model)
+
       if model_obj.import_on_gpu and not torch.cuda.is_available():
         raise RuntimeError("Model can only be exported on CUDA.")
 

--- a/common_benchmark_suite/openxla/benchmark/comparative_suite/tf/scripts/generate_model_artifacts.py
+++ b/common_benchmark_suite/openxla/benchmark/comparative_suite/tf/scripts/generate_model_artifacts.py
@@ -5,7 +5,6 @@
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 import argparse
-import importlib
 import os
 import pathlib
 import re
@@ -16,7 +15,7 @@ import sys
 import tarfile
 import tensorflow as tf
 
-from typing import Any, Optional, Tuple, Union
+from typing import Any, Optional, Tuple
 
 # Add openxla dir to the search path.
 sys.path.insert(0, str(pathlib.Path(__file__).parents[5]))
@@ -80,9 +79,7 @@ def _generate_artifacts(model: def_types.Model, save_dir: pathlib.Path,
     os.environ[
         "XLA_FLAGS"] = f"--xla_dump_to={hlo_dir} --xla_dump_hlo_module_re=.*inference_forward.*"
 
-    model_module = importlib.import_module(model.model_impl.module_path)
-    model_obj: model_interfaces.InferenceModel = model_module.create_model(
-        **model.model_parameters)
+    model_obj = utils.create_model_obj(model)
 
     inputs = utils.generate_and_save_inputs(model_obj, model_dir)
     outputs = model_obj.forward(inputs)

--- a/common_benchmark_suite/openxla/benchmark/devices/__init__.py
+++ b/common_benchmark_suite/openxla/benchmark/devices/__init__.py
@@ -4,7 +4,7 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-from . import gcp_devices
+from . import gcp_devices, host_devices
 
 # All defined device specs.
-ALL_DEVICES = gcp_devices.ALL_DEVICES
+ALL_DEVICES = gcp_devices.ALL_DEVICES + host_devices.ALL_DEVICES

--- a/common_benchmark_suite/openxla/benchmark/devices/host_devices.py
+++ b/common_benchmark_suite/openxla/benchmark/devices/host_devices.py
@@ -1,0 +1,31 @@
+# Copyright 2023 The OpenXLA Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+from openxla.benchmark import def_types
+
+HOST_GPU = def_types.DeviceSpec(
+    name="host-gpu",
+    host_type="host",
+    host_model="unknown",
+    host_environment="unknown",
+    accelerator_type="gpu",
+    accelerator_model="unknown",
+    accelerator_architecture="unknown",
+    accelerator_attributes={},
+)
+
+HOST_CPU = def_types.DeviceSpec(
+    name="host-cpu",
+    host_type="host",
+    host_model="unknown",
+    host_environment="unknown",
+    accelerator_type="cpu",
+    accelerator_model="unknown",
+    accelerator_architecture="unknown",
+    accelerator_attributes={},
+)
+
+ALL_DEVICES = [HOST_GPU, HOST_CPU]

--- a/comparative_benchmark/benchmark_lib.py
+++ b/comparative_benchmark/benchmark_lib.py
@@ -265,7 +265,6 @@ def benchmark(
 
     inputs_npy_dir = model_dir / "inputs_npy"
     input_npys = list(inputs_npy_dir.glob("input_*.npy"))
-
     benchmarks_to_inputs[benchmark.name] = input_npys
 
     # If generate_artifacts is enabled, no expected output to compare.
@@ -275,7 +274,6 @@ def benchmark(
 
     outputs_npy_dir = model_dir / "outputs_npy"
     expect_npys = list(outputs_npy_dir.glob("output_*.npy"))
-
     benchmarks_to_expects[benchmark.name] = expect_npys
 
   if verbose:

--- a/comparative_benchmark/jax_xla/run_benchmarks.py
+++ b/comparative_benchmark/jax_xla/run_benchmarks.py
@@ -7,7 +7,6 @@
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 import argparse
-import importlib
 import jax
 import numpy as np
 import pathlib
@@ -25,7 +24,7 @@ sys.path.insert(
 
 from openxla.benchmark import def_types
 from openxla.benchmark.comparative_suite.jax import benchmark_definitions
-from openxla.benchmark.models import model_interfaces
+import openxla.benchmark.models.utils as model_utils
 import benchmark_lib
 
 
@@ -38,10 +37,7 @@ def _run_framework_benchmark(
     verbose: bool,
 ) -> Tuple[Dict[str, Any], Any]:
 
-  model_module = importlib.import_module(model.model_impl.module_path)
-  model_obj: model_interfaces.InferenceModel = model_module.create_model(
-      **model.model_parameters)
-
+  model_obj = model_utils.create_model_obj(model)
   inputs = [np.load(path) for path in input_npys]
 
   try:

--- a/comparative_benchmark/pt_inductor/run_benchmarks.py
+++ b/comparative_benchmark/pt_inductor/run_benchmarks.py
@@ -14,7 +14,7 @@ import statistics
 import sys
 import time
 import torch
-from typing import Any, Dict, Sequence
+from typing import Any, Dict, Sequence, Tuple
 
 # Add common_benchmark_suite dir to the search path.
 sys.path.insert(
@@ -26,19 +26,17 @@ sys.path.insert(
 from openxla.benchmark import def_types
 from openxla.benchmark.comparative_suite.pt import benchmark_definitions
 from openxla.benchmark.models import model_interfaces
-import benchmark_lib, utils
+import benchmark_lib
 
 
 def _run_framework_benchmark(
     model: def_types.Model,
     input_npys: Sequence[pathlib.Path],
-    expect_npys: Sequence[pathlib.Path],
-    verify_params: Dict[str, Any],
     warmup_iterations: int,
     benchmark_iterations: int,
     backend: str,
     verbose: bool,
-) -> Dict[str, Any]:
+) -> Tuple[Dict[str, Any], Any]:
   try:
 
     data_type = model.model_parameters["data_type"]
@@ -65,7 +63,6 @@ def _run_framework_benchmark(
         **model.model_parameters)
 
     inputs = [np.load(path) for path in input_npys]
-    expects = [np.load(path) for path in expect_npys]
     pt_inputs = [torch.from_numpy(input_data) for input_data in inputs]
 
     if backend == "gpu":
@@ -114,17 +111,13 @@ def _run_framework_benchmark(
     if output is None:
       raise ValueError("No benchmark runs.")
 
-    outputs = (output,)
-    utils.check_tensor_outputs(outputs=outputs,
-                               expects=expects,
-                               verbose=verbose,
-                               **verify_params)
+    last_outputs = (output,)
 
   except Exception as e:
     print(f"Failed to benchmark model {model.name}.")
-    return {"error": str(e)}
+    raise
 
-  result_dict = {
+  metrics = {
       "min_warmup_latency_ms":
           min(warmup_latencies, default=None),
       "max_warmup_latency_ms":
@@ -155,7 +148,7 @@ def _run_framework_benchmark(
       "autotuning_enabled":
           autotuning_enabled,
   }
-  return result_dict
+  return (metrics, last_outputs)
 
 
 def _parse_arguments() -> argparse.Namespace:

--- a/comparative_benchmark/pt_inductor/run_benchmarks.py
+++ b/comparative_benchmark/pt_inductor/run_benchmarks.py
@@ -7,7 +7,6 @@
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 import argparse
-import importlib
 import numpy as np
 import pathlib
 import statistics
@@ -25,7 +24,7 @@ sys.path.insert(
 
 from openxla.benchmark import def_types
 from openxla.benchmark.comparative_suite.pt import benchmark_definitions
-from openxla.benchmark.models import model_interfaces
+import openxla.benchmark.models.utils as model_utils
 import benchmark_lib
 
 
@@ -58,9 +57,7 @@ def _run_framework_benchmark(
     else:
       raise ValueError(f"Backend {backend} not supported.")
 
-    model_module = importlib.import_module(model.model_impl.module_path)
-    model_obj: model_interfaces.InferenceModel = model_module.create_model(
-        **model.model_parameters)
+    model_obj = model_utils.create_model_obj(model)
 
     inputs = [np.load(path) for path in input_npys]
     pt_inputs = [torch.from_numpy(input_data) for input_data in inputs]

--- a/comparative_benchmark/tf_xla/run_benchmarks.py
+++ b/comparative_benchmark/tf_xla/run_benchmarks.py
@@ -7,7 +7,6 @@
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 import argparse
-import importlib
 import numpy as np
 import pathlib
 import statistics
@@ -26,7 +25,7 @@ sys.path.insert(
 
 from openxla.benchmark import def_types
 from openxla.benchmark.comparative_suite.tf import benchmark_definitions
-from openxla.benchmark.models import model_interfaces
+import openxla.benchmark.models.utils as model_utils
 import benchmark_lib
 
 _HLO_DUMP_DIR = "/tmp/hlo_dump"
@@ -53,10 +52,7 @@ def _run_framework_benchmark(
       if tf_device == _TF_GPU_DEVICE:
         tf.config.experimental.reset_memory_stats(tf_device)
 
-      model_module = importlib.import_module(model.model_impl.module_path)
-      model_obj: model_interfaces.InferenceModel = model_module.create_model(
-          **model.model_parameters)
-
+      model_obj = model_utils.create_model_obj(model)
       inputs = [np.load(path) for path in input_npys]
 
       # Run warmup.


### PR DESCRIPTION
Add `--generate-artifacts` options to framework benchmark tools so users can run them without needing to download artifacts.

This is done by first generating the input artifacts then run the benchmarks. This option is useful when adding new benchmarks because their artifacts don't present in GCS yet.

Also add `host-cpu` and `host-gpu` devices for local run.

Here is an example to use this option to run benchmarks locally

```sh
./comparative_benchmark/pt_inductor/run_benchmarks.py \
  -name "models/RESNET50_FP32_PT_.+" \
  -device host-cpu \
  -o /tmp/results.json \
  --generate-artifacts \
  --verbose
```

Tested on CPU benchmarks: https://github.com/openxla/openxla-benchmark/actions/runs/5651537135

Fix #86