### PR TITLE
Expose the filter option in `generate_model_artifacts.sh`

### DIFF
--- a/common_benchmark_suite/openxla/benchmark/comparative_suite/jax/scripts/generate_model_artifacts.sh
+++ b/common_benchmark_suite/openxla/benchmark/comparative_suite/jax/scripts/generate_model_artifacts.sh
@@ -30,7 +30,7 @@ set -xeuo pipefail
 
 TD="$(cd $(dirname $0) && pwd)"
 VENV_DIR="${VENV_DIR:-jax-models.venv}"
-PYTHON="${PYTHON:-"$(which python3)"}"
+PYTHON="${PYTHON:-"$(which python)"}"
 WITH_CUDA="${WITH_CUDA:-}"
 # See https://openxla.github.io/iree/building-from-source/getting-started/ for
 # instructions on how to build `iree-opt`.

--- a/common_benchmark_suite/openxla/benchmark/comparative_suite/jax/scripts/generate_model_artifacts.sh
+++ b/common_benchmark_suite/openxla/benchmark/comparative_suite/jax/scripts/generate_model_artifacts.sh
@@ -13,7 +13,7 @@
 # `gs://iree-model-artifacts/jax`, preserving directory name.
 #
 # Usage:
-#     bash generate_saved_models.sh <path_to_iree_opt>
+#     bash generate_saved_models.sh <(optional) model name regex>
 #
 # Requires python-3.10 and above and python-venv.
 #
@@ -21,6 +21,7 @@
 #   VENV_DIR=jax-models.venv
 #   PYTHON=/usr/bin/python3.10
 #   WITH_CUDA=1
+#   IREE_OPT=iree-opt
 #
 # Positional arguments:
 #   FILTER (Optional): Regex to match models, e.g., BERT_LARGE_FP32_.+
@@ -31,11 +32,17 @@ TD="$(cd $(dirname $0) && pwd)"
 VENV_DIR="${VENV_DIR:-jax-models.venv}"
 PYTHON="${PYTHON:-"$(which python3)"}"
 WITH_CUDA="${WITH_CUDA:-}"
-FILTER="${1:-".+"}"
-
 # See https://openxla.github.io/iree/building-from-source/getting-started/ for
 # instructions on how to build `iree-opt`.
-IREE_OPT_PATH=$1
+IREE_OPT="${IREE_OPT:-"iree-opt"}"
+
+FILTER="${1:-".*"}"
+
+if ! command -v "${IREE_OPT}"; then
+  echo "${IREE_OPT} not found"
+  exit 1
+fi
+IREE_OPT_PATH="$(which "${IREE_OPT}")"
 
 VENV_DIR=${VENV_DIR} PYTHON=${PYTHON} WITH_CUDA=${WITH_CUDA} "${TD}/setup_venv.sh"
 source ${VENV_DIR}/bin/activate

--- a/common_benchmark_suite/openxla/benchmark/comparative_suite/jax/scripts/generate_model_artifacts.sh
+++ b/common_benchmark_suite/openxla/benchmark/comparative_suite/jax/scripts/generate_model_artifacts.sh
@@ -21,13 +21,17 @@
 #   VENV_DIR=jax-models.venv
 #   PYTHON=/usr/bin/python3.10
 #   WITH_CUDA=1
+#
+# Positional arguments:
+#   FILTER (Optional): Regex to match models, e.g., BERT_LARGE_FP32_.+
 
 set -xeuo pipefail
 
 TD="$(cd $(dirname $0) && pwd)"
 VENV_DIR="${VENV_DIR:-jax-models.venv}"
-PYTHON="${PYTHON:-"$(which python)"}"
+PYTHON="${PYTHON:-"$(which python3)"}"
 WITH_CUDA="${WITH_CUDA:-}"
+FILTER="${1:-".+"}"
 
 # See https://openxla.github.io/iree/building-from-source/getting-started/ for
 # instructions on how to build `iree-opt`.
@@ -44,4 +48,9 @@ mkdir "${OUTPUT_DIR}"
 
 pip list > "${OUTPUT_DIR}/models_version_info.txt"
 
-python "${TD}/generate_model_artifacts.py" -o "${OUTPUT_DIR}" --iree_opt_path="${IREE_OPT_PATH}"
+python "${TD}/generate_model_artifacts.py" \
+  -o "${OUTPUT_DIR}" \
+  --iree_opt_path="${IREE_OPT_PATH}" \
+  --filter="${FILTER}"
+
+echo "Output directory: ${OUTPUT_DIR}"

--- a/common_benchmark_suite/openxla/benchmark/comparative_suite/pt/scripts/generate_model_artifacts.sh
+++ b/common_benchmark_suite/openxla/benchmark/comparative_suite/pt/scripts/generate_model_artifacts.sh
@@ -13,7 +13,7 @@
 # `gs://iree-model-artifacts/pt`, preserving directory name.
 #
 # Usage:
-#     bash generate_saved_models.sh
+#     bash generate_saved_models.sh <(optional) model name regex>
 #
 # Requires python-3.11 and above and python-venv.
 #
@@ -31,7 +31,8 @@ TD="$(cd $(dirname $0) && pwd)"
 VENV_DIR="${VENV_DIR:-pt-models.venv}"
 PYTHON="${PYTHON:-"$(which python)"}"
 WITH_CUDA="${WITH_CUDA:-}"
-FILTER="${1:-".+"}"
+
+FILTER="${1:-".*"}"
 
 VENV_DIR=${VENV_DIR} PYTHON=${PYTHON} WITH_CUDA=${WITH_CUDA} "${TD}/setup_venv.sh"
 source ${VENV_DIR}/bin/activate

--- a/common_benchmark_suite/openxla/benchmark/comparative_suite/pt/scripts/generate_model_artifacts.sh
+++ b/common_benchmark_suite/openxla/benchmark/comparative_suite/pt/scripts/generate_model_artifacts.sh
@@ -21,6 +21,9 @@
 #   VENV_DIR=pt-models.venv
 #   PYTHON=/usr/bin/python3.11
 #   WITH_CUDA=1
+#
+# Positional arguments:
+#   FILTER (Optional): Regex to match models, e.g., BERT_LARGE_FP32_.+
 
 set -xeuo pipefail
 
@@ -28,6 +31,7 @@ TD="$(cd $(dirname $0) && pwd)"
 VENV_DIR="${VENV_DIR:-pt-models.venv}"
 PYTHON="${PYTHON:-"$(which python)"}"
 WITH_CUDA="${WITH_CUDA:-}"
+FILTER="${1:-".+"}"
 
 VENV_DIR=${VENV_DIR} PYTHON=${PYTHON} WITH_CUDA=${WITH_CUDA} "${TD}/setup_venv.sh"
 source ${VENV_DIR}/bin/activate
@@ -40,4 +44,8 @@ mkdir "${OUTPUT_DIR}"
 
 pip list > "${OUTPUT_DIR}/models_version_info.txt"
 
-python "${TD}/generate_model_artifacts.py" -o "${OUTPUT_DIR}"
+python "${TD}/generate_model_artifacts.py" \
+  -o "${OUTPUT_DIR}" \
+  --filter="${FILTER}"
+
+echo "Output directory: ${OUTPUT_DIR}"

--- a/common_benchmark_suite/openxla/benchmark/comparative_suite/tf/scripts/generate_model_artifacts.sh
+++ b/common_benchmark_suite/openxla/benchmark/comparative_suite/tf/scripts/generate_model_artifacts.sh
@@ -29,7 +29,7 @@ set -xeuo pipefail
 
 TD="$(cd $(dirname $0) && pwd)"
 VENV_DIR="${VENV_DIR:-tf-models.venv}"
-PYTHON="${PYTHON:-"$(which python3)"}"
+PYTHON="${PYTHON:-"$(which python)"}"
 # See https://openxla.github.io/iree/building-from-source/getting-started/ for
 # instructions on how to build `iree-opt`.
 IREE_OPT="${IREE_OPT:-"iree-opt"}"

--- a/common_benchmark_suite/openxla/benchmark/comparative_suite/tf/scripts/generate_model_artifacts.sh
+++ b/common_benchmark_suite/openxla/benchmark/comparative_suite/tf/scripts/generate_model_artifacts.sh
@@ -20,12 +20,16 @@
 # Environment variables:
 #   VENV_DIR=tf-models.venv
 #   PYTHON=/usr/bin/python3.10
+#
+# Positional arguments:
+#   FILTER (Optional): Regex to match models, e.g., BERT_LARGE_FP32_.+
 
 set -xeuo pipefail
 
 TD="$(cd $(dirname $0) && pwd)"
 VENV_DIR="${VENV_DIR:-tf-models.venv}"
-PYTHON="${PYTHON:-"$(which python)"}"
+PYTHON="${PYTHON:-"$(which python3)"}"
+FILTER="${1:-".+"}"
 
 # See https://openxla.github.io/iree/building-from-source/getting-started/ for
 # instructions on how to build `iree-opt`.
@@ -42,4 +46,9 @@ mkdir ${OUTPUT_DIR}
 
 pip list > "${OUTPUT_DIR}/models_version_info.txt"
 
-python "${TD}/generate_model_artifacts.py" -o "${OUTPUT_DIR}" --iree_opt_path="${IREE_OPT_PATH}"
+python "${TD}/generate_model_artifacts.py" \
+  -o "${OUTPUT_DIR}" \
+  --iree_opt_path="${IREE_OPT_PATH}" \
+  --filter="${FILTER}"
+
+echo "Output directory: ${OUTPUT_DIR}"

--- a/common_benchmark_suite/openxla/benchmark/comparative_suite/tf/scripts/generate_model_artifacts.sh
+++ b/common_benchmark_suite/openxla/benchmark/comparative_suite/tf/scripts/generate_model_artifacts.sh
@@ -13,13 +13,14 @@
 # `gs://iree-model-artifacts/tensorflow`, preserving directory name.
 #
 # Usage:
-#     bash generate_saved_models.sh <path_to_iree_opt>
+#     bash generate_saved_models.sh <(optional) model name regex>
 #
 # Requires python-3.10 and above and python-venv.
 #
 # Environment variables:
 #   VENV_DIR=tf-models.venv
 #   PYTHON=/usr/bin/python3.10
+#   IREE_OPT=iree-opt
 #
 # Positional arguments:
 #   FILTER (Optional): Regex to match models, e.g., BERT_LARGE_FP32_.+
@@ -29,11 +30,17 @@ set -xeuo pipefail
 TD="$(cd $(dirname $0) && pwd)"
 VENV_DIR="${VENV_DIR:-tf-models.venv}"
 PYTHON="${PYTHON:-"$(which python3)"}"
-FILTER="${1:-".+"}"
-
 # See https://openxla.github.io/iree/building-from-source/getting-started/ for
 # instructions on how to build `iree-opt`.
-IREE_OPT_PATH=$1
+IREE_OPT="${IREE_OPT:-"iree-opt"}"
+
+FILTER="${1:-".*"}"
+
+if ! command -v "${IREE_OPT}"; then
+  echo "${IREE_OPT} not found"
+  exit 1
+fi
+IREE_OPT_PATH="$(which "${IREE_OPT}")"
 
 VENV_DIR=${VENV_DIR} PYTHON=${PYTHON} "${TD}/setup_venv.sh"
 source ${VENV_DIR}/bin/activate


### PR DESCRIPTION
Expose the filter option in `generate_model_artifacts.sh`, so users can generate artifacts selectively just in case.

Also print the path of output directory in the end and change the default `python` to `python3` (which seems to be more commonly presented on OS?).

The `iree-opt` is also passed by environment variable `IREE_OPT` instead and try to find it in system paths by default. I feel like this makes it easier to use by not passing `iree-opt` path every time.

Tested with the command on all three scripts:

```sh
common_benchmark_suite/openxla/benchmark/comparative_suite/pt/scripts/generate_model_artifacts.sh "BERT_LARGE_FP32_.+"
```