### PR TITLE
Refactor model forward method to take parameters instead of tuple

### DIFF
--- a/.github/workflows/run_comparative_benchmark.yml
+++ b/.github/workflows/run_comparative_benchmark.yml
@@ -13,7 +13,6 @@ on:
     # Scheduled to run at 09:00 UTC and 21:00 UTC.
     - cron: '0 09,21 * * *'
   workflow_dispatch:
-  pull_request:
 
 concurrency:
   # A PR number if a pull request and otherwise the commit hash. This cancels

--- a/.github/workflows/run_comparative_benchmark.yml
+++ b/.github/workflows/run_comparative_benchmark.yml
@@ -13,6 +13,7 @@ on:
     # Scheduled to run at 09:00 UTC and 21:00 UTC.
     - cron: '0 09,21 * * *'
   workflow_dispatch:
+  pull_request:
 
 concurrency:
   # A PR number if a pull request and otherwise the commit hash. This cancels

--- a/common_benchmark_suite/openxla/benchmark/comparative_suite/tf/scripts/generate_model_artifacts.py
+++ b/common_benchmark_suite/openxla/benchmark/comparative_suite/tf/scripts/generate_model_artifacts.py
@@ -79,9 +79,7 @@ def _generate_artifacts(model: def_types.Model, save_dir: pathlib.Path,
     model_obj = utils.create_model_obj(model)
 
     inputs = utils.generate_and_save_inputs(model_obj, model_dir)
-
     output_obj = model_obj.forward(*inputs)
-
     outputs = utils.canonicalize_to_tuple(output_obj)
     utils.save_outputs(outputs, model_dir)
 

--- a/common_benchmark_suite/openxla/benchmark/comparative_suite/tf/scripts/generate_model_artifacts.py
+++ b/common_benchmark_suite/openxla/benchmark/comparative_suite/tf/scripts/generate_model_artifacts.py
@@ -32,10 +32,7 @@ def _generate_saved_model(inputs: Tuple[Any, ...],
   tensor_specs = []
   for input in inputs:
     tensor_specs.append(tf.TensorSpec.from_tensor(input))
-  # We call the `forward_sm()` version instead of `forward()` because the
-  # SavedModel interface errors when we use an inference function that takes
-  # in Tuples or Lists as input.
-  call_signature = model_obj.forward_sm.get_concrete_function(*tensor_specs)
+  call_signature = model_obj.forward.get_concrete_function(*tensor_specs)
 
   saved_model_dir = model_dir.joinpath("saved_model")
   saved_model_dir.mkdir(exist_ok=True)
@@ -82,7 +79,10 @@ def _generate_artifacts(model: def_types.Model, save_dir: pathlib.Path,
     model_obj = utils.create_model_obj(model)
 
     inputs = utils.generate_and_save_inputs(model_obj, model_dir)
-    outputs = model_obj.forward(inputs)
+
+    output_obj = model_obj.forward(*inputs)
+
+    outputs = utils.canonicalize_to_tuple(output_obj)
     utils.save_outputs(outputs, model_dir)
 
     utils.cleanup_hlo(hlo_dir, model_dir, HLO_FILENAME_REGEX)

--- a/common_benchmark_suite/openxla/benchmark/models/jax/bert/bert_model.py
+++ b/common_benchmark_suite/openxla/benchmark/models/jax/bert/bert_model.py
@@ -36,9 +36,9 @@ class Bert(model_interfaces.InferenceModel):
       # The original model is fp32.
       pass
     elif dtype == jnp.float16:
-      model.params = model.to_fp16(self.model.params)
+      model.params = model.to_fp16(model.params)
     elif dtype == jnp.bfloat16:
-      model.params = model.to_bf16(self.model.params)
+      model.params = model.to_bf16(model.params)
     else:
       raise ValueError(f"Unsupported data type '{dtype}'.")
 

--- a/common_benchmark_suite/openxla/benchmark/models/jax/t5/t5_model.py
+++ b/common_benchmark_suite/openxla/benchmark/models/jax/t5/t5_model.py
@@ -38,7 +38,8 @@ class T5(model_interfaces.InferenceModel):
     decoder_text = "Studies show that"
     return (encoder_text, decoder_text)
 
-  def preprocess(self, encoder_text, decoder_text) -> Tuple[Any, Any]:
+  def preprocess(self, raw_input_obj: Tuple[str, str]) -> Tuple[Any, Any]:
+    encoder_text, decoder_text = raw_input_obj
     batch_encoder_text = [encoder_text] * self.batch_size
     batch_decoder_text = [decoder_text] * self.batch_size
     encoder_input_ids = self.tokenizer(batch_encoder_text,

--- a/common_benchmark_suite/openxla/benchmark/models/model_interfaces.py
+++ b/common_benchmark_suite/openxla/benchmark/models/model_interfaces.py
@@ -3,37 +3,62 @@
 # Licensed under the Apache License v2.0 with LLVM Exceptions.
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-"""Interfaces to interact with JAX models."""
+"""Interfaces to interact with models."""
 
-import abc
+from abc import abstractmethod
 import typing
-from typing import Any
-
-T = typing.TypeVar("T")
-U = typing.TypeVar("U")
-V = typing.TypeVar("V")
+from typing import Any, Protocol, Union
 
 
-class InferenceModel(abc.ABC, typing.Generic[T, U, V]):
-  """Interface to interact with a JAX inference model."""
+@typing.runtime_checkable
+class InferenceModel(Protocol):
+  """Interface to interact with a inference model."""
 
-  @abc.abstractmethod
-  def generate_default_inputs(self) -> T:
-    """Returns default inputs in its raw form."""
-    pass
+  @abstractmethod
+  def generate_default_inputs(self) -> Union[tuple, Any]:
+    """Returns default inputs in its raw form.
 
-  @abc.abstractmethod
-  def preprocess(self, raw_input: T) -> U:
-    """Converts raw inputs into a form that is understandable by the model."""
-    pass
+    Returns:
+      A single raw input or a tuple for multi-value raw input.
+    """
+    ...
 
-  @abc.abstractmethod
-  def forward(self, inputs: U) -> V:
-    """Model inference function."""
-    # TODO(#60): Refactor to not use a tuple as inputs.
-    pass
+  @abstractmethod
+  def preprocess(self, *raw_inputs: Any) -> Union[tuple, Any]:
+    """Converts raw inputs into a form that is understandable by the model.
 
-  @abc.abstractmethod
-  def postprocess(self, outputs: V) -> Any:
-    """Converts raw outputs to a more human-understandable form."""
-    pass
+    It can have multiple parameters for multi-value raw input, e.g., encoder and
+    decoder texts.
+
+    Returns:
+      A single preprocessed input or a tuple for multi-value preprocessed input.
+    """
+    ...
+
+  @abstractmethod
+  def forward(self, *preprocessed_inputs: Any) -> Union[tuple, Any]:
+    """Model inference function.
+
+    It can have multiple parameters for multi-value preprocessed input, e.g.,
+    encoder and decoder input tensors.
+
+    Returns:
+      A single output or a tuple for multi-value output.
+    """
+    ...
+
+  def postprocess(self, *outputs: Any) -> Union[tuple, Any]:
+    """Converts raw outputs to a more human-understandable form.
+
+    It can have multiple parameters for multi-value output.
+
+    The default implementation is no-op.
+
+    Returns:
+      A single postprocessed output or a tuple for multi-value postprocessed
+      output.
+    """
+    # Returns an object instead of tuple if there is only a single argument.
+    if len(outputs) == 1:
+      return outputs[0]
+    return outputs

--- a/common_benchmark_suite/openxla/benchmark/models/model_interfaces.py
+++ b/common_benchmark_suite/openxla/benchmark/models/model_interfaces.py
@@ -9,26 +9,30 @@ from abc import abstractmethod
 import typing
 from typing import Any, Protocol, Union
 
+T = typing.TypeVar("T")
+U = typing.TypeVar("U")
+
 
 @typing.runtime_checkable
-class InferenceModel(Protocol):
+class InferenceModel(Protocol[T, U]):
   """Interface to interact with a inference model."""
 
   @abstractmethod
-  def generate_default_inputs(self) -> Union[tuple, Any]:
+  def generate_default_inputs(self) -> T:
     """Returns default inputs in its raw form.
 
     Returns:
-      A single raw input or a tuple for multi-value raw input.
+      A raw input object, can be a tuple for multi-value raw data.
     """
     ...
 
   @abstractmethod
-  def preprocess(self, *raw_inputs: Any) -> Union[tuple, Any]:
-    """Converts raw inputs into a form that is understandable by the model.
+  def preprocess(self, raw_input_obj: T) -> Union[tuple, Any]:
+    """Converts the raw input object into a form that is understandable by the
+    model.
 
-    It can have multiple parameters for multi-value raw input, e.g., encoder and
-    decoder texts.
+    Due to the compatibility of many ML frameworks, when returning a tuple, it
+    will be treated as an argument list for the forward method.
 
     Returns:
       A single preprocessed input or a tuple for multi-value preprocessed input.
@@ -36,29 +40,23 @@ class InferenceModel(Protocol):
     ...
 
   @abstractmethod
-  def forward(self, *preprocessed_inputs: Any) -> Union[tuple, Any]:
+  def forward(self, *preprocessed_inputs: Any) -> U:
     """Model inference function.
 
     It can have multiple parameters for multi-value preprocessed input, e.g.,
     encoder and decoder input tensors.
 
     Returns:
-      A single output or a tuple for multi-value output.
+      A output object.
     """
     ...
 
-  def postprocess(self, *outputs: Any) -> Union[tuple, Any]:
-    """Converts raw outputs to a more human-understandable form.
-
-    It can have multiple parameters for multi-value output.
+  def postprocess(self, output: U) -> Any:
+    """Converts the output object to a more human-understandable form.
 
     The default implementation is no-op.
 
     Returns:
-      A single postprocessed output or a tuple for multi-value postprocessed
-      output.
+      A postprocessed output.
     """
-    # Returns an object instead of tuple if there is only a single argument.
-    if len(outputs) == 1:
-      return outputs[0]
-    return outputs
+    return output

--- a/common_benchmark_suite/openxla/benchmark/models/model_interfaces_test.py
+++ b/common_benchmark_suite/openxla/benchmark/models/model_interfaces_test.py
@@ -1,0 +1,76 @@
+# Copyright 2023 The OpenXLA Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+"""Test the uses of model interfaces."""
+
+from typing import List, Tuple
+import unittest
+
+from openxla.benchmark.models import model_interfaces
+
+
+class InferenceModelTest(unittest.TestCase):
+
+  def test_protocol_with_single_input(self):
+
+    class TestModel(model_interfaces.InferenceModel):
+
+      def generate_default_inputs(self) -> str:
+        return "abc"
+
+      def preprocess(self, raw_text: str) -> List[int]:
+        return [ord(c) for c in raw_text]
+
+      def forward(self, processed_input: List[int]) -> List[int]:
+        return [num + 1 for num in processed_input]
+
+      def postprocess(self, output: List[int]) -> str:
+        return "".join(chr(num) for num in output)
+
+    model: model_interfaces.InferenceModel = TestModel()
+
+    raw_input = model.generate_default_inputs()
+    processed_input = model.preprocess(raw_input)
+    output = model.forward(processed_input)
+    processed_output = model.postprocess(output)
+
+    self.assertEqual(raw_input, "abc")
+    self.assertEqual(processed_input, [97, 98, 99])
+    self.assertEqual(output, [98, 99, 100])
+    self.assertEqual(processed_output, "bcd")
+
+  def test_protocol_with_tuple_inputs(self):
+
+    class TestModel(model_interfaces.InferenceModel):
+
+      def generate_default_inputs(self) -> Tuple[str, str]:
+        return ("abc", "123")
+
+      def preprocess(self, raw_first: str,
+                     raw_second: str) -> Tuple[List[int], List[int]]:
+        return ([ord(c) for c in raw_first], [ord(c) for c in raw_second])
+
+      def forward(self, first: List[int],
+                  second: List[int]) -> Tuple[List[int], List[int]]:
+        return (second, first)
+
+      def postprocess(self, first_out: List[int], second_out: List[int]) -> str:
+        return "".join(chr(num) for num in (first_out + second_out))
+
+    model: model_interfaces.InferenceModel = TestModel()
+
+    raw_inputs = model.generate_default_inputs()
+    processed_inputs = model.preprocess(*raw_inputs)
+    outputs = model.forward(*processed_inputs)
+    processed_output = model.postprocess(*outputs)
+
+    self.assertEqual(raw_inputs, ("abc", "123"))
+    self.assertEqual(processed_inputs, ([97, 98, 99], [49, 50, 51]))
+    self.assertEqual(outputs, ([49, 50, 51], [97, 98, 99]))
+    self.assertEqual(processed_output, "123abc")
+
+
+if __name__ == "__main__":
+  unittest.main()

--- a/common_benchmark_suite/openxla/benchmark/models/model_interfaces_test.py
+++ b/common_benchmark_suite/openxla/benchmark/models/model_interfaces_test.py
@@ -48,23 +48,27 @@ class InferenceModelTest(unittest.TestCase):
       def generate_default_inputs(self) -> Tuple[str, str]:
         return ("abc", "123")
 
-      def preprocess(self, raw_first: str,
-                     raw_second: str) -> Tuple[List[int], List[int]]:
+      def preprocess(
+          self,
+          raw_obj: Tuple[str, str],
+      ) -> Tuple[List[int], List[int]]:
+        raw_first, raw_second = raw_obj
         return ([ord(c) for c in raw_first], [ord(c) for c in raw_second])
 
       def forward(self, first: List[int],
                   second: List[int]) -> Tuple[List[int], List[int]]:
         return (second, first)
 
-      def postprocess(self, first_out: List[int], second_out: List[int]) -> str:
+      def postprocess(self, out_obj: Tuple[List[int], List[int]]) -> str:
+        first_out, second_out = out_obj
         return "".join(chr(num) for num in (first_out + second_out))
 
     model: model_interfaces.InferenceModel = TestModel()
 
     raw_inputs = model.generate_default_inputs()
-    processed_inputs = model.preprocess(*raw_inputs)
+    processed_inputs = model.preprocess(raw_inputs)
     outputs = model.forward(*processed_inputs)
-    processed_output = model.postprocess(*outputs)
+    processed_output = model.postprocess(outputs)
 
     self.assertEqual(raw_inputs, ("abc", "123"))
     self.assertEqual(processed_inputs, ([97, 98, 99], [49, 50, 51]))

--- a/common_benchmark_suite/openxla/benchmark/models/pt/bert/bert_model.py
+++ b/common_benchmark_suite/openxla/benchmark/models/pt/bert/bert_model.py
@@ -11,7 +11,7 @@ from typing import Any, Dict, Tuple
 from openxla.benchmark.models import model_interfaces
 
 
-class Bert(model_interfaces.InferenceModel, torch.nn.Module):
+class Bert(torch.nn.Module, model_interfaces.InferenceModel):
   """See https://huggingface.co/docs/transformers/model_doc/bert for more
   information.
   """
@@ -46,21 +46,16 @@ class Bert(model_interfaces.InferenceModel, torch.nn.Module):
         "return_tensors": "pt",
     }
 
-  def generate_default_inputs(self) -> Tuple[Any, ...]:
-    input_text = ["a photo of a cat"] * self.batch_size
-    return (input_text,)
+  def generate_default_inputs(self) -> str:
+    return "a photo of a cat"
 
-  def preprocess(self, raw_input: Tuple[Any, ...]) -> Tuple[Any, ...]:
-    input_text, = raw_input
-    inputs = self.tokenizer(text=input_text, **self.tokenization_kwargs)
+  def preprocess(self, input_text: str) -> Tuple[Any, Any]:
+    batch_input_text = [input_text] * self.batch_size
+    inputs = self.tokenizer(text=batch_input_text, **self.tokenization_kwargs)
     return (inputs["input_ids"], inputs["attention_mask"])
 
-  def forward(self, input_ids, attention_mask):
+  def forward(self, input_ids: Any, attention_mask: Any) -> Any:
     return self.model(input_ids, attention_mask)[0]
-
-  def postprocess(self, outputs: Tuple[Any, ...]) -> Tuple[Any, ...]:
-    # No-op.
-    return outputs
 
 
 DTYPE_MAP = {
@@ -80,7 +75,7 @@ def create_model(batch_size: int = 1,
     batch_size: input batch size.
     seq_len: input sequence length. Default to 384.
     data_type: model data type.
-    model_name: The name of the T5 variant to use. Supported variants include:
+    model_name: The name of the Bert variant to use. Supported variants include:
       bert-base-[un]cased, bert-large-[un]cased, bert-base-chinese, etc.
   Returns:
     A PyTorch Bert model.

--- a/common_benchmark_suite/openxla/benchmark/models/tf/resnet/resnet_model.py
+++ b/common_benchmark_suite/openxla/benchmark/models/tf/resnet/resnet_model.py
@@ -4,17 +4,17 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+from PIL import Image
 import tensorflow as tf
-
 from transformers import AutoImageProcessor, TFResNetModel
-from typing import Any, Tuple
+from typing import Any
 
 from openxla.benchmark.models import model_interfaces, utils
 
 DEFAULT_IMAGE_URL = "https://storage.googleapis.com/iree-model-artifacts/ILSVRC2012_val_00000023.JPEG"
 
 
-class ResNet(model_interfaces.InferenceModel, tf.Module):
+class ResNet(tf.Module, model_interfaces.InferenceModel):
   """See https://huggingface.co/docs/transformers/model_doc/resnet for more information."""
 
   batch_size: int
@@ -26,36 +26,21 @@ class ResNet(model_interfaces.InferenceModel, tf.Module):
     self.batch_size = batch_size
     self.model_name = model_name
 
-  def generate_default_inputs(self) -> Tuple[Any, ...]:
+  def generate_default_inputs(self) -> Image.Image:
     # TODO(#44): This should go away once we support different raw inputs.
-    image = utils.download_and_read_img(DEFAULT_IMAGE_URL)
-    return (image,)
+    return utils.download_and_read_img(DEFAULT_IMAGE_URL)
 
-  def preprocess(self, raw_inputs: Tuple[Any, ...]) -> Tuple[Any, ...]:
-    image, = raw_inputs
-    image = image.resize((224, 224))
+  def preprocess(self, input_image: Image.Image) -> Any:
+    resized_image = input_image.resize((224, 224))
     image_processor = AutoImageProcessor.from_pretrained(self.model_name)
-    inputs = image_processor(images=image, return_tensors="tf")
+    inputs = image_processor(images=resized_image, return_tensors="tf")
     tensor = inputs["pixel_values"]
     tensor = tf.tile(tensor, [self.batch_size, 1, 1, 1])
-    return (tensor,)
+    return tensor
 
   @tf.function(jit_compile=True)
-  def forward(self, inputs: Tuple[Any, ...]) -> Tuple[Any, ...]:
-    tensor, = inputs
-    output = self.model(tensor).last_hidden_state
-    return (output,)
-
-  @tf.function(jit_compile=True)
-  def forward_sm(self, inputs):
-    """ Provides an inference interface amenable to generating a TF SavedModel
-    and lowering to MLIR.
-    """
-    return self.model(inputs, training=False).last_hidden_state
-
-  def postprocess(self, outputs: Tuple[Any, ...]) -> Tuple[Any, ...]:
-    # No-op.
-    return outputs
+  def forward(self, input_tensor: Any) -> Any:
+    return self.model(input_tensor, training=False).last_hidden_state
 
 
 def create_model(batch_size: int = 1,

--- a/common_benchmark_suite/openxla/benchmark/models/tf/t5/t5_model.py
+++ b/common_benchmark_suite/openxla/benchmark/models/tf/t5/t5_model.py
@@ -39,11 +39,13 @@ class T5(tf.Module, model_interfaces.InferenceModel):
     decoder_text = "Studies show that"
     return (encoder_text, decoder_text)
 
-  def preprocess(self, encoder_text: str, decoder_text: str) -> Tuple:
-    encoder_input_ids = self.tokenizer([encoder_text] * self.batch_size,
+  def preprocess(self, raw_input_obj: Tuple[str, str]) -> Tuple:
+    encoder_text, decoder_text = raw_input_obj
+    batch_encoder_text = [encoder_text] * self.batch_size
+    batch_decoder_text = [decoder_text] * self.batch_size
+    encoder_input_ids = self.tokenizer(batch_encoder_text,
                                        **self.tokenization_kwargs).input_ids
-
-    decoder_input_ids = self.tokenizer([decoder_text] * self.batch_size,
+    decoder_input_ids = self.tokenizer(batch_decoder_text,
                                        **self.tokenization_kwargs).input_ids
     decoder_input_ids = self.model._shift_right(decoder_input_ids)
 

--- a/common_benchmark_suite/openxla/benchmark/models/utils.py
+++ b/common_benchmark_suite/openxla/benchmark/models/utils.py
@@ -48,8 +48,7 @@ def generate_and_save_inputs(model_obj: model_interfaces.InferenceModel,
   """Generates and preprocesses inputs, then saves it into `model_dir/input_npy.tz`."""
   # TODO(#44): Support multiple raw inputs.
   raw_input_obj = model_obj.generate_default_inputs()
-  raw_inputs = canonicalize_to_tuple(raw_input_obj)
-  input_obj = model_obj.preprocess(*raw_inputs)
+  input_obj = model_obj.preprocess(raw_input_obj)
   inputs = canonicalize_to_tuple(input_obj)
 
   # Save inputs.

--- a/common_benchmark_suite/openxla/benchmark/models/utils.py
+++ b/common_benchmark_suite/openxla/benchmark/models/utils.py
@@ -14,7 +14,7 @@ import re
 import requests
 import shutil
 import tarfile
-from typing import Any, Tuple
+from typing import Any, Tuple, Union
 
 from openxla.benchmark import def_types
 from openxla.benchmark.models import model_interfaces
@@ -27,10 +27,19 @@ def download_and_read_img(url: str) -> Image.Image:
   return img
 
 
-def create_model_obj(model: def_types.Model) -> Any:
+def create_model_obj(model: def_types.Model) -> model_interfaces.InferenceModel:
   """Create model object with the bound parameters."""
   model_module = importlib.import_module(model.model_impl.module_path)
   return model_module.create_model(**model.model_parameters)
+
+
+def canonicalize_to_tuple(return_value: Union[tuple, Any]) -> tuple:
+  """Canonicalize the return value of a model interface method, which may return
+  either a single value or a tuple for multiple values, to tuple.
+  """
+  if isinstance(return_value, tuple):
+    return return_value
+  return (return_value,)
 
 
 def generate_and_save_inputs(model_obj: model_interfaces.InferenceModel,
@@ -38,8 +47,10 @@ def generate_and_save_inputs(model_obj: model_interfaces.InferenceModel,
                              archive: bool = True) -> Tuple[Any, ...]:
   """Generates and preprocesses inputs, then saves it into `model_dir/input_npy.tz`."""
   # TODO(#44): Support multiple raw inputs.
-  raw_inputs = model_obj.generate_default_inputs()
-  inputs = model_obj.preprocess(raw_inputs)
+  raw_input_obj = model_obj.generate_default_inputs()
+  raw_inputs = canonicalize_to_tuple(raw_input_obj)
+  input_obj = model_obj.preprocess(*raw_inputs)
+  inputs = canonicalize_to_tuple(input_obj)
 
   # Save inputs.
   inputs_dir = model_dir / "inputs_npy"

--- a/common_benchmark_suite/openxla/benchmark/models/utils_test.py
+++ b/common_benchmark_suite/openxla/benchmark/models/utils_test.py
@@ -1,0 +1,28 @@
+# Copyright 2023 The OpenXLA Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+import unittest
+
+from openxla.benchmark.models import utils
+
+
+class UtilsTest(unittest.TestCase):
+
+  def test_canonicalize_to_tuple_with_single_value(self):
+
+    result = utils.canonicalize_to_tuple("test")
+
+    self.assertEqual(result, ("test",))
+
+  def test_canonicalize_to_tuple_with_tuple(self):
+
+    result = utils.canonicalize_to_tuple(("a", "b"))
+
+    self.assertEqual(result, ("a", "b"))
+
+
+if __name__ == "__main__":
+  unittest.main()

--- a/comparative_benchmark/pt_inductor/run_benchmarks.py
+++ b/comparative_benchmark/pt_inductor/run_benchmarks.py
@@ -82,7 +82,7 @@ def _run_framework_benchmark(
       output_obj = compiled_model.forward(*pt_inputs)
       if backend == "gpu":
         torch.cuda.synchronize()
-        # Forward function can return either single value or tuple.
+        # Handle the tuple of multi-value output from forward function.
         if isinstance(output_obj, tuple):
           output_obj = tuple(output.cpu() for output in output_obj)
         else:

--- a/comparative_benchmark/pt_inductor/run_benchmarks.py
+++ b/comparative_benchmark/pt_inductor/run_benchmarks.py
@@ -36,7 +36,7 @@ def _run_framework_benchmark(
     compiler: str,
     backend: str,
     verbose: bool,
-) -> Tuple[Dict[str, Any], Any]:
+) -> Tuple[Dict[str, Any], tuple]:
   try:
 
     data_type = model.model_parameters["data_type"]
@@ -79,13 +79,18 @@ def _run_framework_benchmark(
 
     def run_one_iter():
       start = time.perf_counter()
-      output = compiled_model.forward(*pt_inputs)
+      output_obj = compiled_model.forward(*pt_inputs)
       if backend == "gpu":
         torch.cuda.synchronize()
-        output = output.cpu()
+        # Forward function can return either single value or tuple.
+        if isinstance(output_obj, tuple):
+          output_obj = tuple(output.cpu() for output in output_obj)
+        else:
+          output_obj = output_obj.cpu()
       end = time.perf_counter()
+      outputs = model_utils.canonicalize_to_tuple(output_obj)
       latency = 1000 * (end - start)
-      return (output, latency)
+      return (outputs, latency)
 
     # Run warmup.
     warmup_latencies = []
@@ -100,16 +105,15 @@ def _run_framework_benchmark(
 
     # Run benchmark.
     latencies = []
-    output = None
+    last_outputs = None
     for i in range(benchmark_iterations):
-      output, latency = run_one_iter()
+      last_outputs, latency = run_one_iter()
       latencies.append(latency)
-      output = output.detach().numpy()
 
-    if output is None:
+    if last_outputs is None:
       raise ValueError("No benchmark runs.")
 
-    last_outputs = (output,)
+    last_outputs = tuple(output.detach().numpy() for output in last_outputs)
 
   except Exception as e:
     print(f"Failed to benchmark model {model.name}.")


### PR DESCRIPTION
Since many ML frameworks (PyTorch and TF) don't accept tuple as parameters in forward function. Refactor the model interface to use parameters for multi-value inputs.

As the comment in the code, when `preprocess` returns a tuple, it will be treated as the argument list for the forward function, instead of passing the tuple directly.

Also improve the handling on the return value of `preprocess`. Now it can return a single value instead of packing it into a single element tuple. This is done by handling the non-tuple return value in generation scripts. 