### PR TITLE
Option to skip torch-mlir generation

### DIFF
--- a/common_benchmark_suite/openxla/benchmark/comparative_suite/pt/scripts/generate_model_artifacts.py
+++ b/common_benchmark_suite/openxla/benchmark/comparative_suite/pt/scripts/generate_model_artifacts.py
@@ -11,18 +11,32 @@ import multiprocessing
 import shutil
 import sys
 import torch
-import torch_mlir
-
-from import_utils import import_torch_module_with_fx, import_torch_module
 
 # Add openxla dir to the search path.
 sys.path.insert(0, str(pathlib.Path(__file__).parents[5]))
 from openxla.benchmark import def_types
 from openxla.benchmark.comparative_suite.pt import model_definitions
-from openxla.benchmark.models import utils
+from openxla.benchmark.models import model_interfaces, utils
 
 
-def _generate_artifacts(model: def_types.Model, save_dir: pathlib.Path):
+def _import_torch_mlir(model_obj: model_interfaces.InferenceModel,
+                       inputs: tuple, import_with_fx: bool) -> bytes:
+  # Import torch_mlir here to make it optional if mlir generation is not
+  # required.
+  import torch_mlir
+  from import_utils import import_torch_module_with_fx, import_torch_module
+
+  if import_with_fx:
+    return import_torch_module_with_fx(model_obj, inputs,
+                                       torch_mlir.OutputType.LINALG_ON_TENSORS)
+
+  graph = torch.jit.trace(model_obj, inputs)
+  return import_torch_module(graph, inputs,
+                             torch_mlir.OutputType.LINALG_ON_TENSORS)
+
+
+def _generate_artifacts(model: def_types.Model, save_dir: pathlib.Path,
+                        skip_torch_mlir_gen: bool):
   model_dir = save_dir / model.name
   model_dir.mkdir(exist_ok=True)
   print(f"Created {model_dir}")
@@ -37,29 +51,28 @@ def _generate_artifacts(model: def_types.Model, save_dir: pathlib.Path):
       if import_on_gpu and not torch.cuda.is_available():
         raise RuntimeError("Model can only be exported on CUDA.")
 
+      model_obj = utils.create_model_obj(model)
       inputs = utils.generate_and_save_inputs(model_obj, model_dir)
       if import_on_gpu:
         model_obj.cuda()
         inputs = tuple(input.cuda() for input in inputs)
-
-      if import_with_fx:
-        mlir_data = import_torch_module_with_fx(
-            model_obj, inputs, torch_mlir.OutputType.LINALG_ON_TENSORS)
-      else:
-        graph = torch.jit.trace(model_obj, inputs)
-        mlir_data = import_torch_module(graph, inputs,
-                                        torch_mlir.OutputType.LINALG_ON_TENSORS)
-
-      # Save mlir.
-      mlir_path = model_dir / "linalg.mlirbc"
-      print(f"Saving mlir to {mlir_path}")
-      mlir_path.write_bytes(mlir_data)
 
       output_obj = model_obj.forward(*inputs)
 
       outputs = utils.canonicalize_to_tuple(output_obj)
       outputs = tuple(output.cpu() for output in outputs)
       utils.save_outputs(outputs, model_dir)
+
+      if skip_torch_mlir_gen:
+        return
+
+      # Generate and save mlir.
+      mlir_data = _import_torch_mlir(model_obj=model_obj,
+                                     inputs=inputs,
+                                     import_with_fx=import_with_fx)
+      mlir_path = model_dir / "linalg.mlirbc"
+      print(f"Saving mlir to {mlir_path}")
+      mlir_path.write_bytes(mlir_data)
 
   except Exception as e:
     print(f"Failed to import model {model.name}. Exception: {e}")
@@ -70,7 +83,7 @@ def _generate_artifacts(model: def_types.Model, save_dir: pathlib.Path):
 
 def _parse_arguments() -> argparse.Namespace:
   parser = argparse.ArgumentParser(
-      description="Generates JAX model artifacts for benchmarking.")
+      description="Generates PyTorch model artifacts for benchmarking.")
   parser.add_argument("-o",
                       "--output_dir",
                       type=pathlib.Path,
@@ -81,10 +94,15 @@ def _parse_arguments() -> argparse.Namespace:
                       type=str,
                       default=".*",
                       help="The regex pattern to filter model names.")
+  parser.add_argument("--skip-torch-mlir-gen",
+                      "--skip_torch_mlir_gen",
+                      action="store_true",
+                      help="Don't generate torch mlir. Use cautiously when"
+                      " torch-mlir fails to import some models.")
   return parser.parse_args()
 
 
-def main(output_dir: pathlib.Path, filter: str):
+def main(output_dir: pathlib.Path, filter: str, skip_torch_mlir_gen: bool):
   name_pattern = re.compile(f"^{filter}$")
   models = [
       model for model in model_definitions.ALL_MODELS
@@ -100,7 +118,7 @@ def main(output_dir: pathlib.Path, filter: str):
   output_dir.mkdir(parents=True, exist_ok=True)
   for model in models:
     p = multiprocessing.Process(target=_generate_artifacts,
-                                args=(model, output_dir))
+                                args=(model, output_dir, skip_torch_mlir_gen))
     p.start()
     p.join()
 

--- a/common_benchmark_suite/openxla/benchmark/comparative_suite/pt/scripts/generate_model_artifacts.sh
+++ b/common_benchmark_suite/openxla/benchmark/comparative_suite/pt/scripts/generate_model_artifacts.sh
@@ -21,6 +21,7 @@
 #   VENV_DIR=pt-models.venv
 #   PYTHON=/usr/bin/python3.11
 #   WITH_CUDA=1
+#   SKIP_TORCH_MLIR_GEN=0
 #
 # Positional arguments:
 #   FILTER (Optional): Regex to match models, e.g., BERT_LARGE_FP32_.+
@@ -28,25 +29,34 @@
 set -xeuo pipefail
 
 TD="$(cd $(dirname $0) && pwd)"
-VENV_DIR="${VENV_DIR:-pt-models.venv}"
-PYTHON="${PYTHON:-"$(which python)"}"
-WITH_CUDA="${WITH_CUDA:-}"
+export VENV_DIR="${VENV_DIR:-pt-models.venv}"
+export PYTHON="${PYTHON:-"$(which python)"}"
+export WITH_CUDA="${WITH_CUDA:-}"
+export SKIP_TORCH_MLIR_GEN="${SKIP_TORCH_MLIR_GEN:-0}"
 
 FILTER="${1:-".*"}"
 
-VENV_DIR=${VENV_DIR} PYTHON=${PYTHON} WITH_CUDA=${WITH_CUDA} "${TD}/setup_venv.sh"
+"${TD}/setup_venv.sh"
 source ${VENV_DIR}/bin/activate
 
 # Generate unique output directory.
-TORCH_MLIR_VERSION=$(pip show torch-mlir | grep Version | sed -e "s/^Version: \(.*\)$/\1/g")
-DIR_NAME="pt_models_${TORCH_MLIR_VERSION}_$(date +'%s')"
+TORCH_VERSION=$(pip show torch | grep Version | sed -e "s/^Version: \(.*\)$/\1/g")
+TORCH_MLIR_VERSION=$(pip show torch-mlir | grep Version | sed -e "s/^Version: \(.*\)$/\1/g" || echo "none")
+DIR_NAME="pt_models_${TORCH_VERSION}_${TORCH_MLIR_VERSION}_$(date +'%s')"
 OUTPUT_DIR="/tmp/${DIR_NAME}"
 mkdir "${OUTPUT_DIR}"
 
 pip list > "${OUTPUT_DIR}/models_version_info.txt"
 
-python "${TD}/generate_model_artifacts.py" \
-  -o "${OUTPUT_DIR}" \
+declare -a ARGS=(
+  -o "${OUTPUT_DIR}"
   --filter="${FILTER}"
+)
+
+if (( SKIP_TORCH_MLIR_GEN == 1)); then
+  ARGS+=("--skip-torch-mlir-gen")
+fi
+
+python "${TD}/generate_model_artifacts.py" "${ARGS[@]}"
 
 echo "Output directory: ${OUTPUT_DIR}"

--- a/common_benchmark_suite/openxla/benchmark/comparative_suite/pt/scripts/setup_venv.sh
+++ b/common_benchmark_suite/openxla/benchmark/comparative_suite/pt/scripts/setup_venv.sh
@@ -17,6 +17,7 @@ TD="$(cd $(dirname $0) && pwd)"
 VENV_DIR="${VENV_DIR:-pt-models.venv}"
 WITH_CUDA="${WITH_CUDA:-}"
 PYTHON="${PYTHON:-"$(which python)"}"
+SKIP_TORCH_MLIR_GEN="${SKIP_TORCH_MLIR_GEN:-0}"
 
 echo "Setting up venv dir: ${VENV_DIR}"
 
@@ -36,13 +37,14 @@ find "${PT_MODELS_DIR}" -type d | while read dir; do
   fi
 done
 
-if [ -z "$WITH_CUDA" ]
-then
-  echo "Installing torch-mlir and dependencies without cuda support; set WITH_CUDA to enable cuda support."
-  python -m pip install --pre torch-mlir torchvision -f https://llvm.github.io/torch-mlir/package-index/ -f https://download.pytorch.org/whl/nightly/cpu/torch_nightly.html
-else
-  echo "Installing torch-mlir and dependencies with cuda support"
-  python -m pip install --pre torch-mlir torchvision -f https://llvm.github.io/torch-mlir/package-index/ --index-url https://download.pytorch.org/whl/nightly/cu118
+if (( SKIP_TORCH_MLIR_GEN == 0 )); then
+  if [[ -z "${WITH_CUDA}" ]]; then
+    echo "Installing torch-mlir and dependencies without cuda support; set WITH_CUDA to enable cuda support."
+    python -m pip install --pre torch-mlir torchvision -f https://llvm.github.io/torch-mlir/package-index/ -f https://download.pytorch.org/whl/nightly/cpu/torch_nightly.html
+  else
+    echo "Installing torch-mlir and dependencies with cuda support"
+    python -m pip install --pre torch-mlir torchvision -f https://llvm.github.io/torch-mlir/package-index/ --index-url https://download.pytorch.org/whl/nightly/cu118
+  fi
 fi
 
 # Install accelerate after torch-mlir and torch installation to automatically pick a compatible version


### PR DESCRIPTION
Add the option `SKIP_TORCH_MLIR_GEN` in PyTorch artifact generation tool so users can skip MLIR generation when not needed or not possible for models that torch-mlir can't handle. In such cases, the models can still be run in the framework benchmarks but not compiler benchmarks.

Tested locally with:

```
env PYTHON=python3 SKIP_TORCH_MLIR_GEN=1 common_benchmark_suite/openxla/benchmark/comparative_suite/pt/scripts/generate_model_artifacts.sh
```