### PR TITLE
Upload artifacts to gcs automatically

### DIFF
--- a/common_benchmark_suite/openxla/benchmark/comparative_suite/jax/scripts/generate_model_artifacts.sh
+++ b/common_benchmark_suite/openxla/benchmark/comparative_suite/jax/scripts/generate_model_artifacts.sh
@@ -22,6 +22,8 @@
 #   PYTHON=/usr/bin/python3.10
 #   WITH_CUDA=1
 #   IREE_OPT=iree-opt
+#   GCS_UPLOAD_DIR=gs://iree-model-artifacts/jax
+#   AUTO_UPLOAD=1
 #
 # Positional arguments:
 #   FILTER (Optional): Regex to match models, e.g., BERT_LARGE_FP32_.+
@@ -32,6 +34,7 @@ TD="$(cd $(dirname $0) && pwd)"
 VENV_DIR="${VENV_DIR:-jax-models.venv}"
 PYTHON="${PYTHON:-"$(which python)"}"
 WITH_CUDA="${WITH_CUDA:-}"
+AUTO_UPLOAD="${AUTO_UPLOAD:-0}"
 # See https://openxla.github.io/iree/building-from-source/getting-started/ for
 # instructions on how to build `iree-opt`.
 IREE_OPT="${IREE_OPT:-"iree-opt"}"
@@ -47,6 +50,19 @@ IREE_OPT_PATH="$(which "${IREE_OPT}")"
 VENV_DIR=${VENV_DIR} PYTHON=${PYTHON} WITH_CUDA=${WITH_CUDA} "${TD}/setup_venv.sh"
 source ${VENV_DIR}/bin/activate
 
+VENV_DIR_PATH="$(realpath ${VENV_DIR})"
+PYTHON_VERSION="$(python --version | sed -e "s/^Python \(.*\)\.\(.*\)\..*$/\1\.\2/g")"
+
+# `transformers` is not yet up to date with JAX so we need to hack the source to make it compatible.
+BERT_SOURCE_PATH="${VENV_DIR_PATH}/lib/python${PYTHON_VERSION}/site-packages/transformers/models/bert/modeling_flax_bert.py"
+sed -i -e "s/: Optional\[jnp.DeviceArray\] = None/=None/g" "${BERT_SOURCE_PATH}"
+
+T5_SOURCE_PATH="${VENV_DIR_PATH}/lib/python${PYTHON_VERSION}/site-packages/transformers/models/t5/modeling_flax_t5.py"
+sed -i -e "s/: Optional\[jnp.DeviceArray\] = None/=None/g" "${T5_SOURCE_PATH}"
+
+GPT2_SOURCE_PATH="${VENV_DIR_PATH}/lib/python${PYTHON_VERSION}/site-packages/transformers/models/gpt2/modeling_flax_gpt2.py"
+sed -i -e "s/: Optional\[jnp.DeviceArray\] = None/=None/g" "${GPT2_SOURCE_PATH}"
+
 # Generate unique output directory.
 JAX_VERSION=$(pip show jax | grep Version | sed -e "s/^Version: \(.*\)$/\1/g")
 DIR_NAME="jax_models_${JAX_VERSION}_$(date +'%s')"
@@ -55,9 +71,18 @@ mkdir "${OUTPUT_DIR}"
 
 pip list > "${OUTPUT_DIR}/models_version_info.txt"
 
-python "${TD}/generate_model_artifacts.py" \
-  -o "${OUTPUT_DIR}" \
-  --iree_opt_path="${IREE_OPT_PATH}" \
+declare -a args=(
+  -o "${OUTPUT_DIR}"
+  --iree_opt_path="${IREE_OPT_PATH}"
   --filter="${FILTER}"
+)
+
+if (( AUTO_UPLOAD == 1 )); then
+  args+=(
+    --auto_upload
+  )
+fi
+
+python "${TD}/generate_model_artifacts.py" "${args[@]}"
 
 echo "Output directory: ${OUTPUT_DIR}"

--- a/common_benchmark_suite/openxla/benchmark/comparative_suite/pt/scripts/generate_model_artifacts.sh
+++ b/common_benchmark_suite/openxla/benchmark/comparative_suite/pt/scripts/generate_model_artifacts.sh
@@ -21,6 +21,8 @@
 #   VENV_DIR=pt-models.venv
 #   PYTHON=/usr/bin/python3.11
 #   WITH_CUDA=1
+#   GCS_UPLOAD_DIR=gs://iree-model-artifacts/pytorch
+#   AUTO_UPLOAD=1
 #
 # Positional arguments:
 #   FILTER (Optional): Regex to match models, e.g., BERT_LARGE_FP32_.+
@@ -31,6 +33,7 @@ TD="$(cd $(dirname $0) && pwd)"
 VENV_DIR="${VENV_DIR:-pt-models.venv}"
 PYTHON="${PYTHON:-"$(which python)"}"
 WITH_CUDA="${WITH_CUDA:-}"
+AUTO_UPLOAD="${AUTO_UPLOAD:-0}"
 
 FILTER="${1:-".*"}"
 
@@ -45,8 +48,17 @@ mkdir "${OUTPUT_DIR}"
 
 pip list > "${OUTPUT_DIR}/models_version_info.txt"
 
-python "${TD}/generate_model_artifacts.py" \
-  -o "${OUTPUT_DIR}" \
+declare -a args=(
+  -o "${OUTPUT_DIR}"
   --filter="${FILTER}"
+)
+
+if (( AUTO_UPLOAD == 1 )); then
+  args+=(
+    --auto_upload
+  )
+fi
+
+python "${TD}/generate_model_artifacts.py" "${args[@]}"
 
 echo "Output directory: ${OUTPUT_DIR}"

--- a/common_benchmark_suite/openxla/benchmark/comparative_suite/pt/scripts/setup_venv.sh
+++ b/common_benchmark_suite/openxla/benchmark/comparative_suite/pt/scripts/setup_venv.sh
@@ -20,6 +20,9 @@ PYTHON="${PYTHON:-"$(which python)"}"
 
 echo "Setting up venv dir: ${VENV_DIR}"
 
+# Start with a fresh ${VENV_DIR} to ensure torch-mlir is updated.
+rm -rf ${VENV_DIR}
+
 ${PYTHON} -m venv "${VENV_DIR}" || echo "Could not create venv."
 source "${VENV_DIR}/bin/activate" || echo "Could not activate venv"
 

--- a/common_benchmark_suite/openxla/benchmark/comparative_suite/tf/scripts/generate_model_artifacts.py
+++ b/common_benchmark_suite/openxla/benchmark/comparative_suite/tf/scripts/generate_model_artifacts.py
@@ -24,6 +24,8 @@ from openxla.benchmark.comparative_suite.tf import model_definitions
 from openxla.benchmark.models import model_interfaces, utils
 
 HLO_FILENAME_REGEX = r".*inference_forward.*before_optimizations.txt"
+GCS_UPLOAD_DIR = os.getenv("GCS_UPLOAD_DIR",
+                           "gs://iree-model-artifacts/tensorflow")
 
 
 def _generate_saved_model(inputs: Tuple[Any, ...],
@@ -63,7 +65,7 @@ def _generate_mlir(model_dir: pathlib.Path, saved_model_dir: pathlib.Path,
 
 def _generate_artifacts(model: def_types.Model, save_dir: pathlib.Path,
                         iree_import_tf_path: pathlib.Path,
-                        iree_opt_path: pathlib.Path):
+                        iree_opt_path: pathlib.Path, auto_upload: bool):
   model_dir = save_dir.joinpath(model.name)
   model_dir.mkdir(exist_ok=True)
   print(f"Created {model_dir}")
@@ -98,6 +100,11 @@ def _generate_artifacts(model: def_types.Model, save_dir: pathlib.Path,
 
     print(f"Completed generating artifacts {model.name}\n")
 
+    if auto_upload:
+      utils.gcs_upload(str(model_dir),
+                       f"{GCS_UPLOAD_DIR}/{save_dir.name}/{model_dir.name}")
+      shutil.rmtree(model_dir)
+
   except Exception as e:
     print(f"Failed to import model {model.name}. Exception: {e}")
     # Remove all generated files.
@@ -126,11 +133,19 @@ def _parse_arguments() -> argparse.Namespace:
                       type=pathlib.Path,
                       default=None,
                       help="Path to `iree-opt`. Used to binarize mlir.")
+  parser.add_argument(
+      "--auto-upload",
+      "--auto_upload",
+      action="store_true",
+      help=
+      f"If set, uploads artifacts automatically to {GCS_UPLOAD_DIR} and removes them locally once uploaded."
+  )
   return parser.parse_args()
 
 
 def main(output_dir: pathlib.Path, filter: str,
-         iree_import_tf_path: pathlib.Path, iree_opt_path: pathlib.Path):
+         iree_import_tf_path: pathlib.Path, iree_opt_path: pathlib.Path,
+         auto_upload: bool):
   name_pattern = re.compile(f"^{filter}$")
   models = [
       model for model in model_definitions.ALL_MODELS
@@ -149,9 +164,12 @@ def main(output_dir: pathlib.Path, filter: str,
     # XLA to update the HLO dump directory.
     p = multiprocessing.Process(target=_generate_artifacts,
                                 args=(model, output_dir, iree_import_tf_path,
-                                      iree_opt_path))
+                                      iree_opt_path, auto_upload))
     p.start()
     p.join()
+
+  if auto_upload:
+    utils.gcs_upload(f"{output_dir}/**", f"{GCS_UPLOAD_DIR}/{output_dir.name}/")
 
 
 if __name__ == "__main__":

--- a/common_benchmark_suite/openxla/benchmark/comparative_suite/tf/scripts/generate_model_artifacts.sh
+++ b/common_benchmark_suite/openxla/benchmark/comparative_suite/tf/scripts/generate_model_artifacts.sh
@@ -21,6 +21,8 @@
 #   VENV_DIR=tf-models.venv
 #   PYTHON=/usr/bin/python3.10
 #   IREE_OPT=iree-opt
+#   GCS_UPLOAD_DIR=gs://iree-model-artifacts/tensorflow
+#   AUTO_UPLOAD=1
 #
 # Positional arguments:
 #   FILTER (Optional): Regex to match models, e.g., BERT_LARGE_FP32_.+
@@ -30,6 +32,7 @@ set -xeuo pipefail
 TD="$(cd $(dirname $0) && pwd)"
 VENV_DIR="${VENV_DIR:-tf-models.venv}"
 PYTHON="${PYTHON:-"$(which python)"}"
+AUTO_UPLOAD="${AUTO_UPLOAD:-0}"
 # See https://openxla.github.io/iree/building-from-source/getting-started/ for
 # instructions on how to build `iree-opt`.
 IREE_OPT="${IREE_OPT:-"iree-opt"}"
@@ -53,9 +56,18 @@ mkdir ${OUTPUT_DIR}
 
 pip list > "${OUTPUT_DIR}/models_version_info.txt"
 
-python "${TD}/generate_model_artifacts.py" \
-  -o "${OUTPUT_DIR}" \
-  --iree_opt_path="${IREE_OPT_PATH}" \
+declare -a args=(
+  -o "${OUTPUT_DIR}"
+  --iree_opt_path="${IREE_OPT_PATH}"
   --filter="${FILTER}"
+)
+
+if (( AUTO_UPLOAD == 1 )); then
+  args+=(
+    --auto_upload
+  )
+fi
+
+python "${TD}/generate_model_artifacts.py" "${args[@]}"
 
 echo "Output directory: ${OUTPUT_DIR}"

--- a/common_benchmark_suite/openxla/benchmark/models/utils.py
+++ b/common_benchmark_suite/openxla/benchmark/models/utils.py
@@ -13,6 +13,7 @@ import pathlib
 import re
 import requests
 import shutil
+import subprocess
 import tarfile
 from typing import Any, Tuple, Union
 
@@ -96,3 +97,9 @@ def cleanup_hlo(hlo_dir: pathlib.Path, model_dir: pathlib.Path,
   shutil.move(str(hlo_dir.joinpath(hlo_files[0])),
               str(model_dir.joinpath(HLO_STATIC_FILENAME)))
   shutil.rmtree(hlo_dir)
+
+
+def gcs_upload(local_path: str, gcs_path: str):
+  subprocess.run(["gcloud", "storage", "cp", "-r", local_path, gcs_path],
+                 check=True)
+  print(f"Uploaded {local_path} to {gcs_path}")


### PR DESCRIPTION
Artifacts require a lot of disk space. This adds the option to upload artifacts to gcs as each model completes and deletes them locally once uploaded.