### PR TITLE
Import TF to IREE directly instead of using iree-import-tf tool

### DIFF
--- a/common_benchmark_suite/openxla/benchmark/comparative_suite/tf/scripts/generate_model_artifacts.sh
+++ b/common_benchmark_suite/openxla/benchmark/comparative_suite/tf/scripts/generate_model_artifacts.sh
@@ -20,7 +20,6 @@
 # Environment variables:
 #   VENV_DIR=tf-models.venv
 #   PYTHON=/usr/bin/python3.10
-#   IREE_OPT=iree-opt
 #   GCS_UPLOAD_DIR=gs://iree-model-artifacts/tensorflow
 #   AUTO_UPLOAD=1
 #
@@ -33,23 +32,14 @@ TD="$(cd $(dirname $0) && pwd)"
 VENV_DIR="${VENV_DIR:-tf-models.venv}"
 PYTHON="${PYTHON:-"$(which python)"}"
 AUTO_UPLOAD="${AUTO_UPLOAD:-0}"
-# See https://openxla.github.io/iree/building-from-source/getting-started/ for
-# instructions on how to build `iree-opt`.
-IREE_OPT="${IREE_OPT:-"iree-opt"}"
 
 FILTER="${1:-".*"}"
-
-if ! command -v "${IREE_OPT}"; then
-  echo "${IREE_OPT} not found"
-  exit 1
-fi
-IREE_OPT_PATH="$(which "${IREE_OPT}")"
 
 VENV_DIR=${VENV_DIR} PYTHON=${PYTHON} "${TD}/setup_venv.sh"
 source ${VENV_DIR}/bin/activate
 
 # Generate unique output directory.
-TF_VERSION=$(pip show tensorflow | grep Version | sed -e "s/^Version: \(.*\)$/\1/g")
+TF_VERSION=$(pip show tf-nightly | grep Version | sed -e "s/^Version: \(.*\)$/\1/g")
 DIR_NAME="tf_models_${TF_VERSION}_$(date +'%s')"
 OUTPUT_DIR="/tmp/${DIR_NAME}"
 mkdir ${OUTPUT_DIR}
@@ -58,7 +48,6 @@ pip list > "${OUTPUT_DIR}/models_version_info.txt"
 
 declare -a args=(
   -o "${OUTPUT_DIR}"
-  --iree_opt_path="${IREE_OPT_PATH}"
   --filter="${FILTER}"
 )
 

--- a/common_benchmark_suite/openxla/benchmark/comparative_suite/tf/scripts/setup_venv.sh
+++ b/common_benchmark_suite/openxla/benchmark/comparative_suite/tf/scripts/setup_venv.sh
@@ -24,14 +24,18 @@ source "${VENV_DIR}/bin/activate" || echo "Could not activate venv"
 # Upgrade pip and install requirements. 'python' is used here in order to
 # reference to the python executable from the venv.
 python -m pip install --upgrade pip || echo "Could not upgrade pip"
-python -m pip install iree-tools-tf -f https://openxla.github.io/iree/pip-release-links.html
+
+# We need tf-nightly instead of tensorflow.
+python -m pip install tf-nightly
 
 # Run through all model directories and install requirements.
 TF_MODELS_DIR="$(dirname $(dirname $(dirname "${TD}")))/models/tf"
 find "${TF_MODELS_DIR}" -type d | while read dir; do
   if [[ -f "${dir}/requirements.txt" ]]; then
     echo "Installing ${dir}/requirements.txt"
-    python -m pip install --upgrade -r "${dir}/requirements.txt"
+    # Since we want to use tf-nightly, we remove tensorflow from requirements.txt.
+    REQUIREMENTS=$(cat ${dir}/requirements.txt | grep -v "tensorflow" | tr '\n' ' ')
+    python -m pip install --upgrade ${REQUIREMENTS}
   fi
 done
 


### PR DESCRIPTION
It is possible to run into TF dependency version misalignment when generating TF artifacts i.e. the local venv version of TF may be out of sync with the version used in `iree-import-tf`. 

This PR removes use of `iree-import-tf` and imports the TF model into mlir directly using tf.mlir api's.