### PR TITLE
Use iree-ir-tool from IREE release

### DIFF
--- a/common_benchmark_suite/openxla/benchmark/comparative_suite/jax/scripts/generate_model_artifacts.py
+++ b/common_benchmark_suite/openxla/benchmark/comparative_suite/jax/scripts/generate_model_artifacts.py
@@ -28,7 +28,7 @@ GCS_UPLOAD_DIR = os.getenv("GCS_UPLOAD_DIR", "gs://iree-model-artifacts/jax")
 def _generate_mlir(jit_function: Any, jit_inputs: Any, model_dir: pathlib.Path,
                    iree_ir_tool: Optional[pathlib.Path]):
   mlir = jit_function.lower(*jit_inputs).compiler_ir(dialect="stablehlo")
-  mlir_path = model_dir.joinpath("stablehlo.mlir")
+  mlir_path = model_dir / "stablehlo.mlir"
   print(f"Saving mlir to {mlir_path}")
   with open(mlir_path, "w") as f:
     f.write(str(mlir))
@@ -48,13 +48,13 @@ def _generate_mlir(jit_function: Any, jit_inputs: Any, model_dir: pathlib.Path,
 def _generate_artifacts(model: def_types.Model, save_dir: pathlib.Path,
                         iree_ir_tool: Optional[pathlib.Path],
                         auto_upload: bool):
-  model_dir = save_dir.joinpath(model.name)
+  model_dir = save_dir / model.name
   model_dir.mkdir(exist_ok=True)
   print(f"Created {model_dir}")
 
   try:
     # Configure to dump hlo.
-    hlo_dir = model_dir.joinpath("hlo")
+    hlo_dir = model_dir / "hlo"
     hlo_dir.mkdir(exist_ok=True)
     # Only dump hlo for the inference function `jit_model_jitted`.
     os.environ[

--- a/common_benchmark_suite/openxla/benchmark/comparative_suite/jax/scripts/generate_model_artifacts.py
+++ b/common_benchmark_suite/openxla/benchmark/comparative_suite/jax/scripts/generate_model_artifacts.py
@@ -36,8 +36,12 @@ def _generate_mlir(jit_function: Any, jit_inputs: Any, model_dir: pathlib.Path,
   if iree_ir_tool:
     binary_mlir_path = model_dir / "stablehlo.mlirbc"
     subprocess.run(
-        [iree_ir_tool, "--emit-bytecode", mlir_path, "-o", binary_mlir_path],
-        check=True)
+        [
+            iree_ir_tool, "cp", "--emit-bytecode", mlir_path, "-o",
+            binary_mlir_path
+        ],
+        check=True,
+    )
     mlir_path.unlink()
 
 

--- a/common_benchmark_suite/openxla/benchmark/comparative_suite/jax/scripts/generate_model_artifacts.py
+++ b/common_benchmark_suite/openxla/benchmark/comparative_suite/jax/scripts/generate_model_artifacts.py
@@ -46,7 +46,8 @@ def _generate_mlir(jit_function: Any, jit_inputs: Any, model_dir: pathlib.Path,
 
 
 def _generate_artifacts(model: def_types.Model, save_dir: pathlib.Path,
-                        iree_ir_tool: Optional[pathlib.Path], auto_upload: bool):
+                        iree_ir_tool: Optional[pathlib.Path],
+                        auto_upload: bool):
   model_dir = save_dir.joinpath(model.name)
   model_dir.mkdir(exist_ok=True)
   print(f"Created {model_dir}")

--- a/common_benchmark_suite/openxla/benchmark/comparative_suite/jax/scripts/generate_model_artifacts.sh
+++ b/common_benchmark_suite/openxla/benchmark/comparative_suite/jax/scripts/generate_model_artifacts.sh
@@ -21,7 +21,6 @@
 #   VENV_DIR=jax-models.venv
 #   PYTHON=/usr/bin/python3.10
 #   WITH_CUDA=1
-#   IREE_OPT=iree-opt
 #   GCS_UPLOAD_DIR=gs://iree-model-artifacts/jax
 #   AUTO_UPLOAD=1
 #
@@ -35,17 +34,8 @@ VENV_DIR="${VENV_DIR:-jax-models.venv}"
 PYTHON="${PYTHON:-"$(which python)"}"
 WITH_CUDA="${WITH_CUDA:-}"
 AUTO_UPLOAD="${AUTO_UPLOAD:-0}"
-# See https://openxla.github.io/iree/building-from-source/getting-started/ for
-# instructions on how to build `iree-opt`.
-IREE_OPT="${IREE_OPT:-"iree-opt"}"
 
 FILTER="${1:-".*"}"
-
-if ! command -v "${IREE_OPT}"; then
-  echo "${IREE_OPT} not found"
-  exit 1
-fi
-IREE_OPT_PATH="$(which "${IREE_OPT}")"
 
 VENV_DIR=${VENV_DIR} PYTHON=${PYTHON} WITH_CUDA=${WITH_CUDA} "${TD}/setup_venv.sh"
 source ${VENV_DIR}/bin/activate
@@ -63,7 +53,7 @@ pip list > "${OUTPUT_DIR}/models_version_info.txt"
 
 declare -a args=(
   -o "${OUTPUT_DIR}"
-  --iree_opt_path="${IREE_OPT_PATH}"
+  --iree_ir_tool="$(which iree-ir-tool)"
   --filter="${FILTER}"
 )
 

--- a/common_benchmark_suite/openxla/benchmark/comparative_suite/jax/scripts/setup_venv.sh
+++ b/common_benchmark_suite/openxla/benchmark/comparative_suite/jax/scripts/setup_venv.sh
@@ -27,6 +27,11 @@ source "${VENV_DIR}/bin/activate" || echo "Could not activate venv"
 # reference to the python executable from the venv.
 python -m pip install --upgrade pip || echo "Could not upgrade pip"
 
+# Get iree-ir-tool for IR postprocessing.
+python -m pip install \
+  --find-links https://openxla.github.io/iree/pip-release-links.html \
+  iree-compiler
+
 if [ -z "$WITH_CUDA" ]; then
   echo "Installing jax and dependencies without cuda support; set WITH_CUDA to enable cuda support."
   python -m pip install --upgrade "jax[cpu]" "flax"


### PR DESCRIPTION
Replace `iree-opt` with `iree-ir-tool`, which can be installed from the IREE release package