### PR TITLE
Regenerate TFLite FP16 models

### DIFF
--- a/common_benchmark_suite/openxla/benchmark/comparative_suite/jax/scripts/generate_model_artifacts.py
+++ b/common_benchmark_suite/openxla/benchmark/comparative_suite/jax/scripts/generate_model_artifacts.py
@@ -116,6 +116,7 @@ def _generate_tflite_fp16(tf_predict_fn, model_dir: pathlib.Path):
     ]
     converter.optimizations = [tf.lite.Optimize.DEFAULT]
     converter.target_spec.supported_types = [tf.float16]
+    converter.target_spec._experimental_supported_accumulation_type = tf.dtypes.float16
     tflite_model = converter.convert()
     tflite_model_path = model_dir / "model_fp16.tflite"
     tflite_model_path.write_bytes(tflite_model)

--- a/common_benchmark_suite/openxla/benchmark/comparative_suite/tflite/model_definitions.py
+++ b/common_benchmark_suite/openxla/benchmark/comparative_suite/tflite/model_definitions.py
@@ -10,7 +10,7 @@ import string
 from openxla.benchmark import def_types
 from openxla.benchmark.comparative_suite import utils
 
-PARENT_GCS_DIR = "https://storage.googleapis.com/iree-model-artifacts/tflite/tflite_models_1699406784"
+PARENT_GCS_DIR = "https://storage.googleapis.com/iree-model-artifacts/tflite/tflite_models_1701646484"
 ARTIFACTS_DIR_URL_TEMPLATE = string.Template(PARENT_GCS_DIR + "/${name}")
 
 TFLITE_MODEL_IMPL = def_types.ModelImplementation(
@@ -20,7 +20,7 @@ TFLITE_MODEL_IMPL = def_types.ModelImplementation(
     module_path=f"{utils.MODELS_MODULE_PATH}.tflite.tflite_model",
 )
 
-JAX_MODELS_GCS_DIR = "https://storage.googleapis.com/iree-model-artifacts/jax/jax_models_0.4.20_1699872537"
+JAX_MODELS_GCS_DIR = "https://storage.googleapis.com/iree-model-artifacts/jax/jax_models_0.4.20_1701643179"
 
 BERT_BASE_FP32_TFLITE_I32_INPUT_SEQUENCE_TEMPLATE = utils.ModelTemplate(
     name=utils.SEQ_LEN_NAME("BERT_BASE_FP32_TFLITE_I32"),


### PR DESCRIPTION
FP16 models require an additional experimental flag to use the latest XNNPack kernels.