### PR TITLE
Update JAX and TFLite Models

### DIFF
--- a/.github/workflows/run_comparative_benchmark.yml
+++ b/.github/workflows/run_comparative_benchmark.yml
@@ -11,7 +11,6 @@ name: Comparative Benchmarks
 on:
   # Will only run when manually triggered.
   workflow_dispatch:
-  pull_request:
 
 concurrency:
   # A PR number if a pull request and otherwise the commit hash. This cancels

--- a/.github/workflows/run_comparative_benchmark.yml
+++ b/.github/workflows/run_comparative_benchmark.yml
@@ -249,7 +249,7 @@ jobs:
         run: |
           RESULTS_PATH="${RESULTS_DIR}/${JAX_IREE_RESULTS_JSON}"
           docker run --mount="type=bind,src="${PWD}",target=/work" --workdir="/work" \
-            "gcr.io/iree-oss/openxla-benchmark/base-python3.10@sha256:245a074284cfed5de60cf06a153e3bcd9a9c42702b6bb66a39bb47ef23b61669" \
+            "gcr.io/iree-oss/openxla-benchmark/base-python3.11@sha256:b9b98da7bcc5e431800ff798a6dcc394b1838a9ed3d695f5cd0dac3510fc8c8d" \
             ./comparative_benchmark/jax/benchmark_iree.sh \
               "${TARGET_DEVICE}"\
               "${RESULTS_PATH}"

--- a/.github/workflows/run_comparative_benchmark.yml
+++ b/.github/workflows/run_comparative_benchmark.yml
@@ -11,6 +11,7 @@ name: Comparative Benchmarks
 on:
   # Will only run when manually triggered.
   workflow_dispatch:
+  pull_request:
 
 concurrency:
   # A PR number if a pull request and otherwise the commit hash. This cancels

--- a/.github/workflows/run_mobile_comparative_benchmark.yml
+++ b/.github/workflows/run_mobile_comparative_benchmark.yml
@@ -13,6 +13,7 @@ on:
   schedule:
     # Scheduled to run at 09:00 UTC and 21:00 UTC.
     - cron: '0 09,21 * * *'
+  pull_request:
 
 concurrency:
   # A PR number if a pull request and otherwise the commit hash. This cancels

--- a/.github/workflows/run_mobile_comparative_benchmark.yml
+++ b/.github/workflows/run_mobile_comparative_benchmark.yml
@@ -13,7 +13,6 @@ on:
   schedule:
     # Scheduled to run at 09:00 UTC and 21:00 UTC.
     - cron: '0 09,21 * * *'
-  pull_request:
 
 concurrency:
   # A PR number if a pull request and otherwise the commit hash. This cancels

--- a/common_benchmark_suite/openxla/benchmark/comparative_suite/tflite/model_definitions.py
+++ b/common_benchmark_suite/openxla/benchmark/comparative_suite/tflite/model_definitions.py
@@ -10,7 +10,7 @@ import string
 from openxla.benchmark import def_types
 from openxla.benchmark.comparative_suite import utils
 
-PARENT_GCS_DIR = "https://storage.googleapis.com/iree-model-artifacts/tflite/tflite_models_1703027804"
+PARENT_GCS_DIR = "https://storage.googleapis.com/iree-model-artifacts/tflite/tflite_models_1706050932"
 ARTIFACTS_DIR_URL_TEMPLATE = string.Template(PARENT_GCS_DIR + "/${name}")
 
 TFLITE_MODEL_IMPL = def_types.ModelImplementation(
@@ -20,7 +20,7 @@ TFLITE_MODEL_IMPL = def_types.ModelImplementation(
     module_path=f"{utils.MODELS_MODULE_PATH}.tflite.tflite_model",
 )
 
-JAX_MODELS_GCS_DIR = "https://storage.googleapis.com/iree-model-artifacts/jax/jax_models_0.4.23_1702848353"
+JAX_MODELS_GCS_DIR = "https://storage.googleapis.com/iree-model-artifacts/jax/jax_models_0.4.23_1705868085"
 
 BERT_BASE_FP32_TFLITE_I32_INPUT_SEQUENCE_TEMPLATE = utils.ModelTemplate(
     name=utils.SEQ_LEN_NAME("BERT_BASE_FP32_TFLITE_I32"),

--- a/common_benchmark_suite/openxla/benchmark/comparative_suite/tflite/model_definitions.py
+++ b/common_benchmark_suite/openxla/benchmark/comparative_suite/tflite/model_definitions.py
@@ -10,7 +10,7 @@ import string
 from openxla.benchmark import def_types
 from openxla.benchmark.comparative_suite import utils
 
-PARENT_GCS_DIR = "https://storage.googleapis.com/iree-model-artifacts/tflite/tflite_models_1706050932"
+PARENT_GCS_DIR = "https://storage.googleapis.com/iree-model-artifacts/tflite/tflite_models_1706739936"
 ARTIFACTS_DIR_URL_TEMPLATE = string.Template(PARENT_GCS_DIR + "/${name}")
 
 TFLITE_MODEL_IMPL = def_types.ModelImplementation(
@@ -20,7 +20,7 @@ TFLITE_MODEL_IMPL = def_types.ModelImplementation(
     module_path=f"{utils.MODELS_MODULE_PATH}.tflite.tflite_model",
 )
 
-JAX_MODELS_GCS_DIR = "https://storage.googleapis.com/iree-model-artifacts/jax/jax_models_0.4.23_1705868085"
+JAX_MODELS_GCS_DIR = "https://storage.googleapis.com/iree-model-artifacts/jax/jax_models_0.4.23_1706594181"
 
 BERT_BASE_FP32_TFLITE_I32_INPUT_SEQUENCE_TEMPLATE = utils.ModelTemplate(
     name=utils.SEQ_LEN_NAME("BERT_BASE_FP32_TFLITE_I32"),


### PR DESCRIPTION
There have been some recent changes to StableHLO that requires regeneration of JAX and TFLite models. TF model generation is currently broken due to version skews across HuggingFace, TF, and Keras.