### PR TITLE
Enable softmax

### DIFF
--- a/experimental/iree/compile_workloads.py
+++ b/experimental/iree/compile_workloads.py
@@ -37,6 +37,7 @@ IREE_COMPILE_COMMON_FLAGS = [
     "--iree-vm-emit-polyglot-zip=false",
     "--iree-opt-data-tiling",
     "--iree-llvmcpu-enable-ukernels=all",
+    "--iree-llvmcpu-use-decompose-softmax-fuse=false",
 ]
 
 FRAMEWORK_TO_DIALECT = {


### PR DESCRIPTION
Includes `--iree-llvmcpu-use-decompose-softmax-fuse=false` flag when compiling IREE vmfbs.