### PR TITLE
Update contribution guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,52 +1,20 @@
-# How to Contribute
+# How to contribute
 
-We'd love to accept your patches and contributions to this project. There are
-just a few small guidelines you need to follow.
+We'd love to accept your patches and contributions to this project.
 
-## Contributor License Agreement
+To get started with contributing, please take a look at the
+[Contributing](https://iree.dev/developers/general/contributing/) guide.
 
-Contributions to this project must be accompanied by a Contributor License
-Agreement. You (or your employer) retain the copyright to your contribution;
-this simply gives us permission to use and redistribute your contributions as
-part of the project. Head over to <https://cla.developers.google.com/> to see
-your current agreements on file or to sign a new one.
+## Getting in touch
 
-You generally only need to submit a CLA once, so if you've already submitted one
-(even if it was for a different project), you probably don't need to do it
-again.
+*   [GitHub issues](https://github.com/iree-org/iree-comparative-benchmark/issues): Feature requests,
+    bugs, and other work tracking
+*   [IREE Discord server](https://discord.gg/wEWh6Z9nMU): Daily development
+    discussions with the core team and collaborators
+*   [iree-discuss email list](https://groups.google.com/forum/#!forum/iree-discuss):
+    Announcements, general and low-priority discussion
 
-## Changes Accepted
+## Community guidelines
 
-Please file issues before doing substantial work; this will ensure that others
-don't duplicate the work and that there's a chance to discuss any design issues.
-
-Changes only tweaking style are unlikely to be accepted unless they are applied
-consistently across the project. Most of the code style is derived from the
-[Google Style Guides](http://google.github.io/styleguide/) for the appropriate
-language and is generally not something we accept changes on (as clang-format
-and clang-tidy handle that for us). The compiler portion of the project follows
-[MLIR style](https://mlir.llvm.org/getting_started/DeveloperGuide/#style-guide).
-Improvements to code structure and clarity are welcome but please file issues to
-track such work first.
-
-## Code reviews
-
-All submissions, including submissions by project members, require review. We
-use GitHub pull requests (PRs) for this purpose. Consult
-[GitHub Help](https://help.github.com/articles/about-pull-requests/) for more
-information on using pull requests.
-
-## Merging
-
-After review and presubmit checks, PRs should be merged with a "squash and
-merge". The squashed commit summary should match the PR title and the commit
-description should match the PR body. Accordingly, please write these as you
-would a helpful commit message. Please also keep PRs small (focused on a single
-issue) to streamline review and ease later culprit-finding. It is assumed that
-the PR author will merge their change unless they ask someone else to merge it
-for them (e.g. because they don't have write access).
-
-## Community Guidelines
-
-This project follows
-[Google's Open Source Community Guidelines](https://opensource.google.com/conduct/).
+This project follows the
+[LF Projects code of conduct](https://lfprojects.org/policies/code-of-conduct/).


### PR DESCRIPTION
Among other things, IREE was moved out of OpenXLA into the Linux Foundation (LF AI & Data):
https://lfaidata.foundation/blog/2024/05/23/announcing-iree-a-new-initiative-for-machine-learning-deployment/ Therefore, switching the code of conduct to
https://lfprojects.org/policies/code-of-conduct/.